### PR TITLE
chore: Fix workflow syntax

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -189,6 +189,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ github.event.repository.name }
+          service: ${{ github.event.repository.name }}
           cluster: revalidation-preprod
           wait-for-service-stability: true


### PR DESCRIPTION
There is a missing `}` in the template file that was propagated to this
repository.

TISNEW-4785