### PR TITLE
Feature/add existing endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   ext.camelVersion = "3.4.0"
   implementation "org.apache.camel.springboot:camel-spring-boot-starter:$camelVersion"
   implementation "org.apache.camel.springboot:camel-http-starter:$camelVersion"
+  implementation "org.apache.camel.springboot:camel-servlet-starter:$camelVersion"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,9 @@ dependencies {
   }
 
   // Apache Camel starters
-  implementation "org.apache.camel.springboot:camel-spring-boot-starter:3.4.0"
-  implementation "org.apache.camel.springboot:camel-http-starter:3.4.0"
+  ext.camelVersion = "3.4.0"
+  implementation "org.apache.camel.springboot:camel-spring-boot-starter:$camelVersion"
+  implementation "org.apache.camel.springboot:camel-http-starter:$camelVersion"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/api/TraineeApiRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/api/TraineeApiRouter.java
@@ -19,30 +19,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router.service;
+package uk.nhs.hee.tis.revalidation.integration.router.api;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.springframework.beans.factory.annotation.Value;
+import org.apache.camel.model.rest.RestBindingMode;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TcsServiceRouter extends RouteBuilder {
-
-  private static final String API_TRAINEE =
-      "/api/revalidation/trainee/${header.gmcId}?bridgeEndpoint=true";
-  private static final String API_TRAINEES =
-      "/api/revalidation/trainees/${header.gmcIds}?bridgeEndpoint=true";
-
-  @Value("${service.tcs.url}")
-  private String serviceUrl;
+public class TraineeApiRouter extends RouteBuilder {
 
   @Override
   public void configure() {
+    restConfiguration().component("servlet").bindingMode(RestBindingMode.auto);
 
-    from("direct:trainee")
-        .toD(serviceUrl + API_TRAINEE);
+    rest("/trainee/{gmcId}")
+        .get().to("direct:trainee");
 
-    from("direct:trainees")
-        .toD(serviceUrl + API_TRAINEES);
+    rest("/trainees/{gmcIds}")
+        .get().to("direct:trainees");
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/ConcernServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/ConcernServiceRouter.java
@@ -19,34 +19,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router;
+package uk.nhs.hee.tis.revalidation.integration.router.service;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class RecommendationRouter extends RouteBuilder {
+public class ConcernServiceRouter extends RouteBuilder {
 
-  private static final String API_RECOMMENDATION = "/api/recommendation";
-  private static final String API_RECOMMENDATION_GMC_ID =
-      "/api/recommendation/${header.gmcId}?bridgeEndpoint=true";
-  private static final String API_RECOMMENDATION_SUBMIT =
-      "/api/recommendation/${header.gmcId}/submit/${header.recommendationId}?bridgeEndpoint=true";
+  private static final String API_DOCTORS = "/api/doctors";
 
-  @Value("${service.recommendation.url}")
+  @Value("${service.concern.url}")
   private String serviceUrl;
 
   @Override
   public void configure() {
 
-    from("direct:recommendation")
-        .to(serviceUrl + API_RECOMMENDATION);
-
-    from("direct:recommendation-gmc-id")
-        .toD(serviceUrl + API_RECOMMENDATION_GMC_ID);
-
-    from("direct:recommendation-submit")
-        .toD(serviceUrl + API_RECOMMENDATION_SUBMIT);
+    from("direct:concerns")
+        .to(serviceUrl + API_DOCTORS);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/CoreServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/CoreServiceRouter.java
@@ -19,14 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router;
+package uk.nhs.hee.tis.revalidation.integration.router.service;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CoreRouter extends RouteBuilder {
+public class CoreServiceRouter extends RouteBuilder {
 
   private static final String API_DOCTORS = "/api/doctors";
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/GmcClientServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/GmcClientServiceRouter.java
@@ -19,24 +19,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router;
+package uk.nhs.hee.tis.revalidation.integration.router.service;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ConcernRouter extends RouteBuilder {
+public class GmcClientServiceRouter extends RouteBuilder {
 
-  private static final String API_DOCTORS = "/api/doctors";
+  private static final String API_SYNC = "/api/v1/admin";
 
-  @Value("${service.concern.url}")
+  @Value("${service.gmc-client.url}")
   private String serviceUrl;
 
   @Override
   public void configure() {
 
-    from("direct:concerns")
-        .to(serviceUrl + API_DOCTORS);
+    from("direct:gmc-client-sync")
+        .to(serviceUrl + API_SYNC);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
@@ -19,24 +19,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router;
+package uk.nhs.hee.tis.revalidation.integration.router.service;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class GmcClientRouter extends RouteBuilder {
+public class RecommendationServiceRouter extends RouteBuilder {
 
-  private static final String API_SYNC = "/api/v1/admin";
+  private static final String API_RECOMMENDATION = "/api/recommendation";
+  private static final String API_RECOMMENDATION_GMC_ID =
+      "/api/recommendation/${header.gmcId}?bridgeEndpoint=true";
+  private static final String API_RECOMMENDATION_SUBMIT =
+      "/api/recommendation/${header.gmcId}/submit/${header.recommendationId}?bridgeEndpoint=true";
 
-  @Value("${service.gmc-client.url}")
+  @Value("${service.recommendation.url}")
   private String serviceUrl;
 
   @Override
   public void configure() {
 
-    from("direct:gmc-client-sync")
-        .to(serviceUrl + API_SYNC);
+    from("direct:recommendation")
+        .to(serviceUrl + API_RECOMMENDATION);
+
+    from("direct:recommendation-gmc-id")
+        .toD(serviceUrl + API_RECOMMENDATION_GMC_ID);
+
+    from("direct:recommendation-submit")
+        .toD(serviceUrl + API_RECOMMENDATION_SUBMIT);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/TcsServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/TcsServiceRouter.java
@@ -19,14 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router;
+package uk.nhs.hee.tis.revalidation.integration.router.service;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TcsRouter extends RouteBuilder {
+public class TcsServiceRouter extends RouteBuilder {
 
   private static final String API_TRAINEE =
       "/api/revalidation/trainee/${header.gmcId}?bridgeEndpoint=true";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+camel:
+  component:
+    servlet:
+      mapping:
+        context-path: /api/*
+
 server:
   port: 8088
   servlet:


### PR DESCRIPTION
I've renamed the existing endpoint routers to make sure naming stays unique when we add the API from API Gateway.
My thinking is to have a `<service name>ServiceRouter` for each backend service (e.g. `TcsServiceRouter`) then `<view/function name>ApiRouter` for each API/FE function (eg. `ConcernsApiRouter` or `TraineeApiRouter`).
Open to suggestions about naming or a better way to segregate the configuration.

Created `TraineeApiRouter` as an example of what a router for a function could look like.

Also changed the Camel context path from `<service url>/camel/<endpoint path>` to `<service url>/api/<endpoint path>`