### PR TITLE
feat: Add Sentry DSN and Environment variables

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -66,6 +66,14 @@
         {
           "name": "COMMON_UPLOAD_PORT",
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-common-upload-port"
+        },
+        {
+          "name": "SENTRY_DSN",
+          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-integration-sentry-dsn"
+        },
+        {
+          "name": "SENTRY_ENVIRONMENT",
+          "value": "stage"
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Example:
 ```
 
 ## TODO
- - Provide `SENTRY_DSN` and `SENTRY_ENVIRONMENT` as environmental variables
-   during deployment.
+ - Provide dynamic `SENTRY_ENVIRONMENT` as environmental variable during
+   deployment, this should be set based on where the container is being
+   deployed i.e. `stage` or `prod`.
 
 ## Workflow
 The `CI/CD Workflow` is triggered on push to any branch.


### PR DESCRIPTION
Add `SENTRY_DSN` and `SENTRY_ENVIRONMENT` to the task definition file so
that exceptions are able to be sent to the Sentry project.

TISNEW-4890