### PR TITLE
fix: Move `SENTRY_ENVIRONMENT` to correct location

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -16,6 +16,10 @@
         {
           "name": "AWS_REGION",
           "value": "eu-west-2"
+        },
+        {
+          "name": "SENTRY_ENVIRONMENT",
+          "value": "stage"
         }
       ],
       "logConfiguration": {
@@ -70,10 +74,6 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-integration-sentry-dsn"
-        },
-        {
-          "name": "SENTRY_ENVIRONMENT",
-          "value": "stage"
         }
       ]
     }


### PR DESCRIPTION
The `SENTRY_ENVIRONMENT` variable was placed in to the `secrets` array,
when it should be in the `environment` array.

TISNEW-4890