### PR TITLE
fix: Return current user's details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.3.1"
+version = "0.3.2"
 sourceCompatibility = "11"
 
 configurations {


### PR DESCRIPTION
Currently the details of the machine user are returned instead of the
details of the logged in user, change the endpoint used when requesting
the admin profile to get one that can get by username instead of from
the current token.

TISNEW-5344