### PR TITLE
fix: add connection status in null hidden connection route

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/aggregation/ConnectionHiddenAggregationStrategy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/aggregation/ConnectionHiddenAggregationStrategy.java
@@ -67,6 +67,13 @@ public class ConnectionHiddenAggregationStrategy implements AggregationStrategy 
   private ConnectionHiddenDto aggregateTraineeWithConnectionAllowNull(Exchange newExchange) {
     final var body = newExchange.getIn().getBody();
     final var connectionHiddenDto = mapper.convertValue(body, ConnectionHiddenDto.class);
+    final var connections = connectionHiddenDto.getConnections();
+    final var connectionHiddenRecordDtos = connections.stream().map(conn -> {
+      conn.setConnectionStatus(getConnectionStatus(conn.getDesignatedBody()));
+      return conn;
+    }).collect(toList());
+
+    connectionHiddenDto.setConnections(connectionHiddenRecordDtos);
     return connectionHiddenDto;
 
   }


### PR DESCRIPTION
The previous fix did not cover the logic for the connection status field. This is to add connection status logic in the route when hidden connection is null.

TIS21-109