### PR TITLE
feat: view trainee notes

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/aggregation/TraineeNotesAggregationStrategy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/aggregation/TraineeNotesAggregationStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2021 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/aggregation/TraineeNotesAggregationStrategy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/aggregation/TraineeNotesAggregationStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.router.aggregation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.revalidation.integration.router.dto.TraineeDetailsDto;
+import uk.nhs.hee.tis.revalidation.integration.router.dto.TraineeNotesDto;
+
+@Slf4j
+@Component
+public class TraineeNotesAggregationStrategy implements AggregationStrategy {
+
+  @Autowired
+  private ObjectMapper mapper;
+
+  @SneakyThrows
+  @Override
+  public Exchange aggregate(final Exchange oldExchange, final Exchange newExchange) {
+    final var result = new DefaultExchange(new DefaultCamelContext());
+
+    final var messageBody = oldExchange.getIn().getBody();
+    final var traineeDetailsDto = mapper
+        .convertValue(messageBody, TraineeDetailsDto.class);
+
+    final var notesMessageBody = newExchange.getIn().getBody();
+    final var traineeNotesDto = mapper.convertValue(notesMessageBody, TraineeNotesDto.class);
+    traineeDetailsDto.setNotes(traineeNotesDto.getNotes());
+
+    result.getMessage().setBody(traineeDetailsDto);
+    return result;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeDetailsDto.java
@@ -19,25 +19,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router.api;
+package uk.nhs.hee.tis.revalidation.integration.router.dto;
 
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.model.rest.RestBindingMode;
-import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Component
-public class TraineeApiRouter extends RouteBuilder {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TraineeDetailsDto {
 
-  @Override
-  public void configure() {
-    restConfiguration().component("servlet");
-
-    rest("/trainee/{gmcId}")
-        .get().bindingMode(RestBindingMode.auto)
-        .to("direct:trainee");
-
-    rest("/trainees/{gmcIds}")
-        .get().bindingMode(RestBindingMode.off)
-        .to("direct:trainees");
-  }
+  private String gmcNumber;
+  private String forenames;
+  private String surname;
+  private LocalDate cctDate;
+  private String programmeMembershipType;
+  private String programmeName;
+  private String currentGrade;
+  private Integer tisPersonId;
+  private List<TraineeNotesInfoDto> notes;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeDetailsDto.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2021 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeNotesDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeNotesDto.java
@@ -1,7 +1,6 @@
 /*
  * The MIT License (MIT)
- *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2021 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,25 +18,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router.api;
+package uk.nhs.hee.tis.revalidation.integration.router.dto;
 
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.model.rest.RestBindingMode;
-import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Component
-public class TraineeApiRouter extends RouteBuilder {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TraineeNotesDto {
 
-  @Override
-  public void configure() {
-    restConfiguration().component("servlet");
-
-    rest("/trainee/{gmcId}")
-        .get().bindingMode(RestBindingMode.auto)
-        .to("direct:trainee");
-
-    rest("/trainees/{gmcIds}")
-        .get().bindingMode(RestBindingMode.off)
-        .to("direct:trainees");
-  }
+  private String gmcId;
+  private List<TraineeNotesInfoDto> notes;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeNotesInfoDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/TraineeNotesInfoDto.java
@@ -1,7 +1,6 @@
 /*
  * The MIT License (MIT)
- *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2021 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,25 +18,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.router.api;
+package uk.nhs.hee.tis.revalidation.integration.router.dto;
 
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.model.rest.RestBindingMode;
-import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Component
-public class TraineeApiRouter extends RouteBuilder {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TraineeNotesInfoDto {
 
-  @Override
-  public void configure() {
-    restConfiguration().component("servlet");
-
-    rest("/trainee/{gmcId}")
-        .get().bindingMode(RestBindingMode.auto)
-        .to("direct:trainee");
-
-    rest("/trainees/{gmcIds}")
-        .get().bindingMode(RestBindingMode.off)
-        .to("direct:trainees");
-  }
+  private String id;
+  private String gmcId;
+  private String text;
+  private LocalDate createdDate;
+  private LocalDate updatedDate;
 }


### PR DESCRIPTION
Trainee Notes data are added to trainee details endpoint `/api/trainee/{gmcId}/`.
It would be called by left side component of all details page (recommendations / concerns / connections) for the trainee information)

TIS21-86