### PR TITLE
feat: added revalidation fields to master index

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/RevalidationSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/RevalidationSummaryDto.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RevalidationSummaryDto {
+
+  private DoctorsForDB doctor;
+  private String gmcOutcome;
+  @Nullable
+  Boolean syncEnd;
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/RevalidationSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/dto/RevalidationSummaryDto.java
@@ -19,13 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.entity;
+package uk.nhs.hee.tis.revalidation.integration.router.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.lang.Nullable;
+import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
 
 @Data
 @AllArgsConstructor
@@ -35,6 +35,4 @@ public class RevalidationSummaryDto {
 
   private DoctorsForDB doctor;
   private String gmcOutcome;
-  @Nullable
-  Boolean syncEnd;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/message/payload/IndexSyncMessage.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/message/payload/IndexSyncMessage.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.router.message.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class IndexSyncMessage<T> {
+  private T payload;
+  private Boolean syncEnd;
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListener.java
@@ -48,7 +48,7 @@ public class GmcDoctorMessageListener {
   @Value("${app.rabbit.reval.queue.connection.getmaster}")
   private String esGetMasterQueueName;
 
-  @Value("${app.rabbit.reval.routingKey.connection.getmaster}")
+  @Value("${app.rabbit.reval.routingKey.indexrebuildgetmastercommand.requested}")
   private String esGetMasterRoutingKey;
 
   @Autowired

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
@@ -36,6 +36,8 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
+import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -59,8 +61,14 @@ public class MasterDoctorView {
   private String programmeName;
   private String membershipType;
   private String designatedBody;
+  private String gmcStatus;
+  private RecommendationStatus tisStatus;
+  private String admin;
+  private LocalDate lastUpdatedDate;
+  private UnderNotice underNotice;
   private String tcsDesignatedBody;
   private String programmeOwner;
+  private LocalDate curriculumEndDate;
   private String connectionStatus;
   @Nullable
   @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
@@ -70,5 +78,4 @@ public class MasterDoctorView {
   @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private LocalDate membershipEndDate;
-
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
@@ -64,10 +64,16 @@ public class MasterDoctorView {
   private String gmcStatus;
   private RecommendationStatus tisStatus;
   private String admin;
+  @Nullable
+  @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private LocalDate lastUpdatedDate;
   private UnderNotice underNotice;
   private String tcsDesignatedBody;
   private String programmeOwner;
+  @Nullable
+  @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private LocalDate curriculumEndDate;
   private String connectionStatus;
   @Nullable

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,7 +77,7 @@ app:
     reval.routingKey.connection.syncstart: ${REVAL_RABBIT_SYNCSTART_ROUTING_KEY:reval.connection.syncstart}
     reval.routingKey.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNCSTART_ROUTING_KEY:reval.recommendation.syncstart}
     reval.routingKey.connection.syncdata: ${REVAL_RABBIT_SYNCDATA_ROUTING_KEY:reval.connection.syncdata}
-    reval.routingKey.connection.getmaster: ${REVAL_RABBIT_GETMASTER_ROUTING_KEY:reval.connection.getmaster}
+    reval.indexrebuildgetmastercommand.requested: ${REVAL_RABBIT_GETMASTER_ROUTING_KEY:reval.connection.getmaster}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,7 +77,7 @@ app:
     reval.routingKey.connection.syncstart: ${REVAL_RABBIT_SYNCSTART_ROUTING_KEY:reval.connection.syncstart}
     reval.routingKey.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNCSTART_ROUTING_KEY:reval.recommendation.syncstart}
     reval.routingKey.connection.syncdata: ${REVAL_RABBIT_SYNCDATA_ROUTING_KEY:reval.connection.syncdata}
-    reval.indexrebuildgetmastercommand.requested: ${REVAL_RABBIT_GETMASTER_ROUTING_KEY:reval.connection.getmaster}
+    reval.routingKey.indexrebuildgetmastercommand.requested: ${REVAL_RABBIT_GETMASTER_ROUTING_KEY:reval.indexrebuildgetmastercommand.requested}
 
 logging:
   level:

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListenerTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
 import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
+import uk.nhs.hee.tis.revalidation.integration.entity.RevalidationSummaryDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.DoctorUpsertElasticSearchService;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
@@ -42,6 +43,7 @@ import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 @ExtendWith(MockitoExtension.class)
 class GmcDoctorMessageListenerTest {
 
+  private RevalidationSummaryDto revalidationSummaryDto;
   private DoctorsForDB doctorsForDB;
 
   @InjectMocks
@@ -64,11 +66,14 @@ class GmcDoctorMessageListenerTest {
         .designatedBodyCode("PQR")
         .admin("Reval Admin").build();
 
+    revalidationSummaryDto = RevalidationSummaryDto.builder()
+        .doctor(doctorsForDB)
+        .gmcOutcome("Approved").build();
   }
 
   @Test
   void testMessagesAreReceivedFromSqsQueue() {
-    gmcDoctorMessageListener.getMessage(doctorsForDB);
+    gmcDoctorMessageListener.getMessage(revalidationSummaryDto);
 
     ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = ArgumentCaptor
         .forClass(MasterDoctorView.class);
@@ -82,5 +87,4 @@ class GmcDoctorMessageListenerTest {
     assertThat(masterDoctorView.getDesignatedBody(), is("PQR"));
     assertThat(masterDoctorView.getConnectionStatus(), is("Yes"));
   }
-
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListenerTest.java
@@ -35,14 +35,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
 import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
-import uk.nhs.hee.tis.revalidation.integration.entity.RevalidationSummaryDto;
+import uk.nhs.hee.tis.revalidation.integration.router.dto.RevalidationSummaryDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
+import uk.nhs.hee.tis.revalidation.integration.router.message.payload.IndexSyncMessage;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.DoctorUpsertElasticSearchService;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 
 @ExtendWith(MockitoExtension.class)
 class GmcDoctorMessageListenerTest {
 
+  private IndexSyncMessage<RevalidationSummaryDto> message;
   private RevalidationSummaryDto revalidationSummaryDto;
   private DoctorsForDB doctorsForDB;
 
@@ -69,11 +71,14 @@ class GmcDoctorMessageListenerTest {
     revalidationSummaryDto = RevalidationSummaryDto.builder()
         .doctor(doctorsForDB)
         .gmcOutcome("Approved").build();
+
+    message = new IndexSyncMessage<RevalidationSummaryDto>();
+    message.setPayload(revalidationSummaryDto);
   }
 
   @Test
   void testMessagesAreReceivedFromSqsQueue() {
-    gmcDoctorMessageListener.getMessage(revalidationSummaryDto);
+    gmcDoctorMessageListener.getMessage(message);
 
     ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = ArgumentCaptor
         .forClass(MasterDoctorView.class);


### PR DESCRIPTION
TIS21-2669

The additional fields which are needed to make the revalidation summary page for elastic search index is added in this PR. The fields are being received from the sqs queue.