### PR TITLE
fix: update master index mapper

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
@@ -23,9 +23,11 @@ package uk.nhs.hee.tis.revalidation.integration.router.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface MasterDoctorViewMapper {
 
   @Mapping(target = "gmcReferenceNumber", ignore = true)

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
@@ -114,7 +114,7 @@ public class DoctorUpsertElasticSearchService {
       MasterDoctorView dataToSave) {
     try {
       existingRecords.forEach(currentDoctorView -> {
-        repository.save(mapper.updateMasterDoctorView(currentDoctorView, dataToSave));
+        repository.save(mapper.updateMasterDoctorView(dataToSave, currentDoctorView));
       });
     }
     catch (Exception ex) {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
@@ -29,12 +29,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
 import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapperImpl;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
-import uk.nhs.hee.tis.revalidation.integration.entity.*;
 
 @ExtendWith(MockitoExtension.class)
-public class MasterDoctorViewMapperTest {
+class MasterDoctorViewMapperTest {
 
   @InjectMocks
   MasterDoctorViewMapperImpl masterDoctorViewMapper;
@@ -67,7 +67,8 @@ public class MasterDoctorViewMapperTest {
     dataToSave.setTcsDesignatedBody("tcsDesignatedBody_new");
     dataToSave.setProgrammeOwner("programmeOwner_new");
 
-    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(
+        dataToSave, currentDoctorView);
 
     assertThat(result.getId(), is("1a2b3c"));
     assertThat(result.getTcsPersonId(), is(1001L));
@@ -91,7 +92,8 @@ public class MasterDoctorViewMapperTest {
     dataToSave.setGmcStatus("gmcStatus");
     dataToSave.setTisStatus(RecommendationStatus.COMPLETED);
 
-    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(
+        dataToSave, currentDoctorView);
 
     assertThat(result.getId(), is("1a2b3c"));
     assertThat(result.getTcsPersonId(), is(1001L));
@@ -116,7 +118,8 @@ public class MasterDoctorViewMapperTest {
     dataToSave.setTcsDesignatedBody(null);
     dataToSave.setProgrammeOwner(null);
 
-    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(
+        dataToSave, currentDoctorView);
 
     assertThat(result.getId(), is("1a2b3c"));
     assertThat(result.getTcsPersonId(), is(1001L));
@@ -131,12 +134,13 @@ public class MasterDoctorViewMapperTest {
     assertThat(result.getGmcReferenceNumber(), is("gmcReferenceNumber"));
     assertThat(result.getDoctorFirstName(), is("doctorFirstName"));
     assertThat(result.getDoctorLastName(), is("doctorLastName"));
-}
+  }
 
   @Test
   void shouldNotUpdateMasterDoctorViewsWhenNull() {
     MasterDoctorView dataToSave = null;
-    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(
+        dataToSave, currentDoctorView);
 
     assertThat(result, nullValue());
   }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License (MIT)
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.router.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapperImpl;
+import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
+import uk.nhs.hee.tis.revalidation.integration.entity.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MasterDoctorViewMapperTest {
+
+  @InjectMocks
+  MasterDoctorViewMapperImpl masterDoctorViewMapper;
+
+  private MasterDoctorView currentDoctorView;
+
+  @BeforeEach
+  void setUp() {
+
+    currentDoctorView = MasterDoctorView.builder()
+        .id("1a2b3c")
+        .tcsPersonId(1001L)
+        .gmcReferenceNumber("gmcReferenceNumber")
+        .doctorFirstName("doctorFirstName")
+        .doctorLastName("doctorLastName")
+        .programmeName("programmeName")
+        .membershipType("membershipType")
+        .designatedBody("designatedBody")
+        .tcsDesignatedBody("tcsDesignatedBody")
+        .programmeOwner("programmeOwner")
+        .connectionStatus("Yes")
+        .build();
+  }
+
+  @Test
+  void shouldUpdateMasterDoctorViewsToNewValues() {
+    MasterDoctorView dataToSave = new MasterDoctorView();
+    dataToSave.setProgrammeName("programmeName_new");
+    dataToSave.setMembershipType("membershipType_new");
+    dataToSave.setTcsDesignatedBody("tcsDesignatedBody_new");
+    dataToSave.setProgrammeOwner("programmeOwner_new");
+
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+
+    assertThat(result.getId(), is("1a2b3c"));
+    assertThat(result.getTcsPersonId(), is(1001L));
+
+    //mapper will make sure new values are populated
+    assertThat(result.getProgrammeName(), is("programmeName_new"));
+    assertThat(result.getMembershipType(), is("membershipType_new"));
+    assertThat(result.getTcsDesignatedBody(), is("tcsDesignatedBody_new"));
+    assertThat(result.getProgrammeOwner(), is("programmeOwner_new"));
+
+    //other fields will remain same
+    assertThat(result.getGmcReferenceNumber(), is("gmcReferenceNumber"));
+    assertThat(result.getDoctorFirstName(), is("doctorFirstName"));
+    assertThat(result.getDoctorLastName(), is("doctorLastName"));
+  }
+
+  @Test
+  void shouldUpdateMasterDoctorViewsWithNewFields() {
+    MasterDoctorView dataToSave = new MasterDoctorView();
+    dataToSave.setAdmin("admin");
+    dataToSave.setGmcStatus("gmcStatus");
+    dataToSave.setTisStatus(RecommendationStatus.COMPLETED);
+
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+
+    assertThat(result.getId(), is("1a2b3c"));
+    assertThat(result.getTcsPersonId(), is(1001L));
+
+    //mapper will make sure new fields are populated
+    assertThat(result.getAdmin(), is("admin"));
+    assertThat(result.getGmcStatus(), is("gmcStatus"));
+    assertThat(result.getTisStatus(), is(RecommendationStatus.COMPLETED));
+
+    //other fields will remain same
+    assertThat(result.getGmcReferenceNumber(), is("gmcReferenceNumber"));
+    assertThat(result.getDoctorFirstName(), is("doctorFirstName"));
+    assertThat(result.getDoctorLastName(), is("doctorLastName"));
+    assertThat(result.getProgrammeOwner(), is("programmeOwner"));
+  }
+
+  @Test
+  void shouldNotUpdateMasterDoctorFieldsWhenFieldsNull() {
+    MasterDoctorView dataToSave = new MasterDoctorView();
+    dataToSave.setProgrammeName(null);
+    dataToSave.setMembershipType(null);
+    dataToSave.setTcsDesignatedBody(null);
+    dataToSave.setProgrammeOwner(null);
+
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+
+    assertThat(result.getId(), is("1a2b3c"));
+    assertThat(result.getTcsPersonId(), is(1001L));
+
+    //mapper will make sure null fields will not override the existing values
+    assertThat(result.getProgrammeName(), is("programmeName"));
+    assertThat(result.getMembershipType(), is("membershipType"));
+    assertThat(result.getTcsDesignatedBody(), is("tcsDesignatedBody"));
+    assertThat(result.getProgrammeOwner(), is("programmeOwner"));
+
+    //other fields will remain same
+    assertThat(result.getGmcReferenceNumber(), is("gmcReferenceNumber"));
+    assertThat(result.getDoctorFirstName(), is("doctorFirstName"));
+    assertThat(result.getDoctorLastName(), is("doctorLastName"));
+}
+
+  @Test
+  void shouldNotUpdateMasterDoctorViewsWhenNull() {
+    MasterDoctorView dataToSave = null;
+    MasterDoctorView result = masterDoctorViewMapper.updateMasterDoctorView(dataToSave, currentDoctorView);
+
+    assertThat(result, nullValue());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -24,17 +24,16 @@ package uk.nhs.hee.tis.revalidation.integration.sync.service;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapperImpl;
+import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapper;
 import uk.nhs.hee.tis.revalidation.integration.sync.repository.MasterDoctorElasticSearchRepository;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
-import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapper;
 
 @ExtendWith(MockitoExtension.class)
 class DoctorUpsertElasticSearchServiceTest {
@@ -46,7 +45,9 @@ class DoctorUpsertElasticSearchServiceTest {
   private MasterDoctorViewMapper mapper;
 
   private DoctorUpsertElasticSearchService service;
-  private MasterDoctorView currentDoctorView, dataToSave, mappedView;
+  private MasterDoctorView currentDoctorView;
+  private MasterDoctorView dataToSave;
+  private MasterDoctorView mappedView;
   private List<MasterDoctorView> recordsAlreadyInEs = new ArrayList<>();
 
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -21,14 +21,11 @@
 
 package uk.nhs.hee.tis.revalidation.integration.sync.service;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapperImpl;
 import uk.nhs.hee.tis.revalidation.integration.sync.repository.MasterDoctorElasticSearchRepository;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
+import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapper;
 
 @ExtendWith(MockitoExtension.class)
 class DoctorUpsertElasticSearchServiceTest {
@@ -44,164 +42,107 @@ class DoctorUpsertElasticSearchServiceTest {
   @Mock
   private MasterDoctorElasticSearchRepository repository;
 
+  @Mock
+  private MasterDoctorViewMapper mapper;
+
   private DoctorUpsertElasticSearchService service;
-  private MasterDoctorView currentDoctorView, dataToSave;
+  private MasterDoctorView currentDoctorView, dataToSave, mappedView;
+  private List<MasterDoctorView> recordsAlreadyInEs = new ArrayList<>();
+
 
   @BeforeEach
   void setUp() {
-    service = new DoctorUpsertElasticSearchService(repository, new MasterDoctorViewMapperImpl());
+    service = new DoctorUpsertElasticSearchService(repository, mapper);
     currentDoctorView = MasterDoctorView.builder()
+        .id("1a2b3c")
         .tcsPersonId(1001L)
         .gmcReferenceNumber("56789")
-        .doctorFirstName("AAAAA")
-        .doctorLastName("BBBB")
-        .submissionDate(LocalDate.now())
-        .programmeName("Medicine")
-        .membershipType("Visitor")
-        .designatedBody("EoE")
-        .tcsDesignatedBody("KSS")
-        .programmeOwner("East of England")
-        .connectionStatus("Yes")
+        .doctorFirstName("doctorFirstName")
+        .doctorLastName("doctorLastName")
         .build();
 
     dataToSave = MasterDoctorView.builder()
+        .doctorFirstName("doctorFirstName")
+        .doctorLastName("doctorLastName_new")
+        .build();
+
+    mappedView = MasterDoctorView.builder()
+        .id("1a2b3c")
         .tcsPersonId(1001L)
         .gmcReferenceNumber("56789")
-        .doctorFirstName("AAAAA")
-        .doctorLastName("BBBB")
-        .submissionDate(LocalDate.now())
-        .programmeName("")
-        .membershipType("")
-        .designatedBody("EoE")
-        .tcsDesignatedBody("")
-        .programmeOwner("")
-        .connectionStatus("Yes")
+        .doctorFirstName("doctorFirstName_new")
+        .doctorLastName("doctorLastName_new")
         .build();
+
+    // prepare existing record in ES Master
+    recordsAlreadyInEs.add(currentDoctorView);
   }
 
   @Test
-  void shouldUpdateMasterDoctorViewsWhenRecordIsFoundInEs() {
-    List<MasterDoctorView> recordsAlreadyInEs = new ArrayList<>();
-    //the id is needed as it will be the record already in the ES
-    currentDoctorView.setId("1a2b3c");
-    recordsAlreadyInEs.add(currentDoctorView);
+  void shouldUpdateMasterDoctorViewsWithGmcIdAndPersonId() {
+    // set dataToSave with TcsPersonId and GmcReferenceNumber
+    dataToSave.setTcsPersonId(1001L);
+    dataToSave.setGmcReferenceNumber("56789");
 
+    // find es index by GmcReferenceNumber and TcsPersonId will return and existing record
     when(repository
         .findByGmcReferenceNumberAndTcsPersonId(dataToSave.getGmcReferenceNumber(), dataToSave.getTcsPersonId()))
         .thenReturn(recordsAlreadyInEs);
+    when(mapper.updateMasterDoctorView(dataToSave, currentDoctorView)).thenReturn(mappedView);
 
-    //id which is unique needs to be set to avoid duplicate rows while updating the record in ES
-    dataToSave.setId(recordsAlreadyInEs.get(0).getId());
-
-    //this will lead to updateMasterDoctorViews() as record is there already in the ES
     service.populateMasterIndex(dataToSave);
 
-    assertThat(dataToSave.getId(), is("1a2b3c"));
-    assertThat(dataToSave.getTcsPersonId(), is(1001L));
-
-    //mapper will make sure all the TIS data fields are populated
-    assertThat(dataToSave.getProgrammeName(), is("Medicine"));
-    assertThat(dataToSave.getMembershipType(), is("Visitor"));
-    assertThat(dataToSave.getTcsDesignatedBody(), is("KSS"));
-    assertThat(dataToSave.getProgrammeOwner(), is("East of England"));
-
-    //gmc fields will remain same
-    assertThat(dataToSave.getGmcReferenceNumber(), is("56789"));
-    assertThat(dataToSave.getDoctorFirstName(), is("AAAAA"));
-    assertThat(dataToSave.getDoctorLastName(), is("BBBB"));
+    // should update index with mappedView
+    verify(repository).save(mappedView);
   }
 
   @Test
-  void shouldUpdateMasterDoctorViewsWhenRecordIsFoundInEsPersonIdNull() {
-    List<MasterDoctorView> recordsAlreadyInEs = new ArrayList<>();
-    //the id is needed as it will be the record already in the ES
-    currentDoctorView.setId("1a2b3c");
-    recordsAlreadyInEs.add(currentDoctorView);
+  void shouldUpdateMasterDoctorViewsWithGmcId() {
+    // set dataToSave with GmcReferenceNumber
+    dataToSave.setGmcReferenceNumber("56789");
 
-    dataToSave.setTcsPersonId(null);
+    // find es index by GmcReferenceNumber will return and existing record
     when(repository
         .findByGmcReferenceNumber(dataToSave.getGmcReferenceNumber()))
         .thenReturn(recordsAlreadyInEs);
+    when(mapper.updateMasterDoctorView(dataToSave, currentDoctorView)).thenReturn(mappedView);
 
-    //id which is unique needs to be set to avoid duplicate rows while updating the record in ES
-    dataToSave.setId(recordsAlreadyInEs.get(0).getId());
-
-    //this will lead to updateMasterDoctorViews() as record is there already in the ES
     service.populateMasterIndex(dataToSave);
 
-    assertThat(dataToSave.getId(), is("1a2b3c"));
-    assertThat(dataToSave.getTcsPersonId(), is(1001L));
-
-    //mapper will make sure all the TIS data fields are populated
-    assertThat(dataToSave.getProgrammeName(), is("Medicine"));
-    assertThat(dataToSave.getMembershipType(), is("Visitor"));
-    assertThat(dataToSave.getTcsDesignatedBody(), is("KSS"));
-    assertThat(dataToSave.getProgrammeOwner(), is("East of England"));
-
-    //gmc fields will remain same
-    assertThat(dataToSave.getGmcReferenceNumber(), is("56789"));
-    assertThat(dataToSave.getDoctorFirstName(), is("AAAAA"));
-    assertThat(dataToSave.getDoctorLastName(), is("BBBB"));
+    // should update index with mappedView
+    verify(repository).save(mappedView);
   }
 
   @Test
-  void shouldUpdateMasterDoctorViewsWhenRecordIsFoundInEsGmcIdNull() {
-    List<MasterDoctorView> recordsAlreadyInEs = new ArrayList<>();
-    //the id is needed as it will be the record already in the ES
-    currentDoctorView.setId("1a2b3c");
-    recordsAlreadyInEs.add(currentDoctorView);
+  void shouldUpdateMasterDoctorViewsWithPersonId() {
+    // set dataToSave with TcsPersonId
+    dataToSave.setTcsPersonId(1001L);
 
-    dataToSave.setGmcReferenceNumber(null);
+    // find es index by TcsPersonId will return and existing record
     when(repository
         .findByTcsPersonId(dataToSave.getTcsPersonId()))
         .thenReturn(recordsAlreadyInEs);
+    when(mapper.updateMasterDoctorView(dataToSave, currentDoctorView)).thenReturn(mappedView);
 
-    //id which is unique needs to be set to avoid duplicate rows while updating the record in ES
-    dataToSave.setId(recordsAlreadyInEs.get(0).getId());
-
-    //this will lead to updateMasterDoctorViews() as record is there already in the ES
     service.populateMasterIndex(dataToSave);
 
-    assertThat(dataToSave.getId(), is("1a2b3c"));
-    assertThat(dataToSave.getTcsPersonId(), is(1001L));
-
-    //mapper will make sure all the TIS data fields are populated
-    assertThat(dataToSave.getProgrammeName(), is("Medicine"));
-    assertThat(dataToSave.getMembershipType(), is("Visitor"));
-    assertThat(dataToSave.getTcsDesignatedBody(), is("KSS"));
-    assertThat(dataToSave.getProgrammeOwner(), is("East of England"));
-
-    //gmc fields will remain same
-    assertThat(dataToSave.getDoctorFirstName(), is("AAAAA"));
-    assertThat(dataToSave.getDoctorLastName(), is("BBBB"));
+    // should update index with mappedView
+    verify(repository).save(mappedView);
   }
 
   @Test
   void shouldAddMasterDoctorViewsWhenRecordIsNotInEs() {
-    //this is an empty record list
-    List<MasterDoctorView> recordsAlreadyInEs = new ArrayList<>();
+    // set dataToSave with a different GmcReferenceNumber
+    dataToSave.setGmcReferenceNumber("12345");
 
-    //this is a new record, so query will return nothing
+    // find es index by GmcReferenceNumber don't return any existing record
     when(repository
-        .findByGmcReferenceNumberAndTcsPersonId(dataToSave.getGmcReferenceNumber(), dataToSave.getTcsPersonId()))
-        .thenReturn(recordsAlreadyInEs);
+        .findByGmcReferenceNumber(dataToSave.getGmcReferenceNumber()))
+        .thenReturn(new ArrayList<>());
 
-    //this will lead to addMasterDoctorViews() as no record found
     service.populateMasterIndex(dataToSave);
 
+    // should save index with dataToSave
     verify(repository).save(dataToSave);
-
-    assertThat(dataToSave.getGmcReferenceNumber(), is("56789"));
-    assertThat(dataToSave.getDoctorFirstName(), is("AAAAA"));
-    assertThat(dataToSave.getDoctorLastName(), is("BBBB"));
-    assertThat(dataToSave.getSubmissionDate(), is(LocalDate.now()));
-    assertThat(dataToSave.getDesignatedBody(), is("EoE"));
-    assertThat(dataToSave.getConnectionStatus(), is("Yes"));
-
-    //gmc doesn't know about TIS data
-    assertThat(dataToSave.getProgrammeName(), is(""));
-    assertThat(dataToSave.getMembershipType(), is(""));
-    assertThat(dataToSave.getTcsDesignatedBody(), is(""));
-    assertThat(dataToSave.getProgrammeOwner(), is(""));
   }
 }


### PR DESCRIPTION
- swap source and target param passing to the mapper
- add annotation so target field won't be overridden when source is null

TIS21-2669: Filter Recommendations with ES - Rebuild ES Job