### PR TITLE
fix: /v1/doctors routes to recommendation directly

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/api/V1ApiRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/api/V1ApiRouter.java
@@ -36,10 +36,9 @@ public class V1ApiRouter extends RouteBuilder {
         .post().bindingMode(RestBindingMode.off)
         .to("direct:admin");
 
-    // TODO: Change to direct:doctors when tis-revalidation-core is deployed.
     rest("/v1/doctors")
         .get().bindingMode(RestBindingMode.auto)
-        .to("direct:temp-doctors");
+        .to("direct:v1-doctors");
 
     // TODO: Change to use tis-revalidation-core when deployed.
     rest("/v1/doctors/assign-admin")


### PR DESCRIPTION
/v1/doctors doesn't need enrich with multiple services any more. 
It just needs to route to Recommendation service and get data from ES recommendationIndex.

TIS21-2675