### PR TITLE
refactor: check ES by TIS ID if GMC is placeholder

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateService.java
@@ -35,7 +35,7 @@ import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 @Service
 public class CdcTraineeUpdateService extends CdcService<ConnectionInfoDto> {
 
-  private final Predicate<String> ignoredGMCNumbers =
+  private final Predicate<String> isUnreliableGmcNumber =
       s -> s == null || s.isBlank() || "UNKNOWN".equalsIgnoreCase(s);
 
   private final MasterDoctorViewMapper mapper;
@@ -60,10 +60,10 @@ public class CdcTraineeUpdateService extends CdcService<ConnectionInfoDto> {
     final String receivedGmcReferenceNumber = receivedDto.getGmcReferenceNumber();
     log.debug("Attempting to upsert document for GMC Ref: [{}]", receivedGmcReferenceNumber);
     final var existingView =
-        (ignoredGMCNumbers.test(receivedGmcReferenceNumber) ? Optional.<MasterDoctorView>empty()
+        (isUnreliableGmcNumber.test(receivedGmcReferenceNumber) ? Optional.<MasterDoctorView>empty()
             : repository.findByGmcReferenceNumber(receivedGmcReferenceNumber).stream().findFirst())
             .orElse(repository.findByTcsPersonId(receivedDto.getTcsPersonId()).stream().findFirst()
-        .orElse(new MasterDoctorView()));
+                .orElse(new MasterDoctorView()));
 
     final var updatedView = repository
         .save(mapper.updateMasterDoctorView(receivedDto, existingView));

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateService.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.revalidation.integration.cdc.service;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.ConnectionInfoDto;
@@ -34,7 +35,10 @@ import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 @Service
 public class CdcTraineeUpdateService extends CdcService<ConnectionInfoDto> {
 
-  private MasterDoctorViewMapper mapper;
+  private final Predicate<String> ignoredGMCNumbers =
+      s -> s == null || s.isBlank() || "UNKNOWN".equalsIgnoreCase(s);
+
+  private final MasterDoctorViewMapper mapper;
 
   /**
    * Service responsible for updating the Trainee composite fields used for searching.
@@ -54,11 +58,12 @@ public class CdcTraineeUpdateService extends CdcService<ConnectionInfoDto> {
   public void upsertEntity(ConnectionInfoDto receivedDto) {
     final var repository = getRepository();
     final String receivedGmcReferenceNumber = receivedDto.getGmcReferenceNumber();
+    log.debug("Attempting to upsert document for GMC Ref: [{}]", receivedGmcReferenceNumber);
     final var existingView =
-        ("UNKNOWN".equalsIgnoreCase(receivedGmcReferenceNumber) ? Optional.<MasterDoctorView>empty()
+        (ignoredGMCNumbers.test(receivedGmcReferenceNumber) ? Optional.<MasterDoctorView>empty()
             : repository.findByGmcReferenceNumber(receivedGmcReferenceNumber).stream().findFirst())
             .orElse(repository.findByTcsPersonId(receivedDto.getTcsPersonId()).stream().findFirst()
-                .orElse(new MasterDoctorView()));
+        .orElse(new MasterDoctorView()));
 
     final var updatedView = repository
         .save(mapper.updateMasterDoctorView(receivedDto, existingView));

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcTraineeUpdateServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcTraineeUpdateServiceTest.java
@@ -35,7 +35,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -129,7 +130,6 @@ class CdcTraineeUpdateServiceTest {
 
   @Test
   void shouldUpsertTraineeInfoIfGmcNumberNull() {
-    when(repository.findByGmcReferenceNumber(null)).thenReturn(Collections.emptyList());
     final var masterDoctorViewNullGmc = CdcTestDataGenerator.getTestMasterDoctorView();
     masterDoctorViewNullGmc.setGmcReferenceNumber(null);
     when(repository.findByTcsPersonId(tcsPersonId)).thenReturn(List.of(masterDoctorViewNullGmc));
@@ -145,7 +145,8 @@ class CdcTraineeUpdateServiceTest {
   }
 
   @ParameterizedTest(name = "Should Find Existing by TIS ID if GMC Number is [{0}]")
-  @CsvSource(value = {"Unknown", "UNKNOWN", "unknown"})
+  @NullAndEmptySource
+  @ValueSource(strings = {"Unknown", "UNKNOWN", "unknown", " "})
   void shouldFindExistingByTisIdIfUnknownGmc(String unknown) {
     traineeUpdate.setGmcReferenceNumber(unknown);
     when(repository.findByTcsPersonId(tcsPersonId)).thenReturn(List.of(masterDoctorView));
@@ -157,7 +158,6 @@ class CdcTraineeUpdateServiceTest {
 
   @Test
   void shouldInsertTraineeInfoIfNoMatch() {
-    when(repository.findByGmcReferenceNumber(any())).thenReturn(Collections.emptyList());
     final var masterDoctorViewNullGmc = CdcTestDataGenerator.getTestMasterDoctorView();
     masterDoctorViewNullGmc.setGmcReferenceNumber(null);
     when(repository.findByTcsPersonId(any())).thenReturn(Collections.emptyList());
@@ -190,7 +190,6 @@ class CdcTraineeUpdateServiceTest {
   @Test
   void shouldPublishUpdateForTcsId() {
     MasterDoctorView view2 = CdcTestDataGenerator.getTestMasterDoctorView();
-    when(repository.findByGmcReferenceNumber(null)).thenReturn(Collections.emptyList());
     when(repository.findByTcsPersonId(tcsPersonId)).thenReturn(List.of(masterDoctorView, view2));
     MasterDoctorView updatedView = new MasterDoctorView();
     when(repository.save(any())).thenReturn(updatedView);


### PR DESCRIPTION
Searching for null or empty GMC numbers will return all matches.
The visible problem is logging when there are >10K matches.
There is a bigger problem about updating based on GMC number when TIS ID
 doesn't match but that a data quality issue.

TIS21-2675: Filtering by Programme Name