### PR TITLE
fix:allow some TCS null value update to ES

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.4.0"
+version = "0.4.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
@@ -46,17 +46,17 @@ public interface MasterDoctorViewMapper {
    * @return a partially populated {@link MasterDoctorView}
    */
   @Mapping(source = "programmeName", target = "programmeName",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   @Mapping(source = "programmeMembershipType", target = "membershipType",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   @Mapping(source = "programmeOwner", target = "programmeOwner",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   @Mapping(source = "curriculumEndDate", target = "curriculumEndDate",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   @Mapping(source = "programmeMembershipStartDate", target = "membershipStartDate",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   @Mapping(source = "programmeMembershipEndDate", target = "membershipEndDate",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   MasterDoctorView updateMasterDoctorView(ConnectionInfoDto source,
       @MappingTarget MasterDoctorView target);
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
@@ -45,6 +45,18 @@ public interface MasterDoctorViewMapper {
    * @param source Information from TCS used in the context of Revalidation
    * @return a partially populated {@link MasterDoctorView}
    */
+  @Mapping(source = "programmeName", target = "programmeName",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  @Mapping(source = "programmeMembershipType", target = "membershipType",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  @Mapping(source = "programmeOwner", target = "programmeOwner",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  @Mapping(source = "curriculumEndDate", target = "curriculumEndDate",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  @Mapping(source = "programmeMembershipStartDate", target = "membershipStartDate",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  @Mapping(source = "programmeMembershipEndDate", target = "membershipEndDate",
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   MasterDoctorView updateMasterDoctorView(ConnectionInfoDto source,
       @MappingTarget MasterDoctorView target);
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
@@ -173,4 +173,23 @@ class MasterDoctorViewMapperTest {
     assertThat(result.getGmcReferenceNumber(), is(source.getGmcReferenceNumber()));
     assertThat(result.getTcsPersonId(), is(source.getTcsPersonId()));
   }
+
+  @Test
+  void shouldUpdateNullTcsProgrammeFields() {
+    ConnectionInfoDto source = ConnectionInfoDto.builder().build();
+    source.setGmcReferenceNumber(GMC_REFERENCE_NUMBER);
+
+    MasterDoctorView result = masterDoctorViewMapper
+        .updateMasterDoctorView(source, currentDoctorView);
+
+    assertThat(result.getConnectionStatus(), is(CONNECTION_YES));
+    assertThat(result.getGmcReferenceNumber(), is(source.getGmcReferenceNumber()));
+    assertThat(result.getTcsPersonId(), is(TIS_ID));
+    assertThat(result.getProgrammeName(), nullValue());
+    assertThat(result.getProgrammeOwner(), nullValue());
+    assertThat(result.getCurriculumEndDate(), nullValue());
+    assertThat(result.getMembershipStartDate(), nullValue());
+    assertThat(result.getMembershipStartDate(), nullValue());
+    assertThat(result.getMembershipEndDate(), nullValue());
+  }
 }


### PR DESCRIPTION
Defatult nullValuePropertyMappingStrategy is `SET_TO_NULL`. 

We've already set the strategy to `IGNORE` on mapper level.
And setting the strategy on bean mapping or field mapping will overwite it.

TIS21-3229