### PR TITLE
fix: disable part of es resync job that kills mongoDB

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListener.java
@@ -61,10 +61,12 @@ public class GmcDoctorMessageListener {
   @SqsListener(value = "${cloud.aws.end-point.uri}")
   public void getMessage(IndexSyncMessage<RevalidationSummaryDto> message) {
     if (message.getSyncEnd() != null && message.getSyncEnd()) {
-      log.info("GMC sync completed. {} trainees in total. Sending message to Connection.",
+      log.info("GMC sync completed. {} trainees in total.",
           traineeCount);
-      String getMaster = "getMaster";
-      rabbitTemplate.convertAndSend(revalExchange, esGetMasterRoutingKey, getMaster);
+      // TODO implement solution using reindex API TIS21-3416
+      /********* Temporarily disable final stage of resync as it takes hours and kills mongodb ********/
+      // String getMaster = "getMaster";
+      // rabbitTemplate.convertAndSend(revalExchange, esGetMasterRoutingKey, getMaster);
       traineeCount = 0;
     } else {
       //prepare the MasterDoctorView and call the service method

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListener.java
@@ -64,9 +64,6 @@ public class GmcDoctorMessageListener {
       log.info("GMC sync completed. {} trainees in total.",
           traineeCount);
       // TODO implement solution using reindex API TIS21-3416
-      /********* Temporarily disable final stage of resync as it takes hours and kills mongodb ********/
-      // String getMaster = "getMaster";
-      // rabbitTemplate.convertAndSend(revalExchange, esGetMasterRoutingKey, getMaster);
       traineeCount = 0;
     } else {
       //prepare the MasterDoctorView and call the service method


### PR DESCRIPTION
TIS21-3491: Do an efficient and targeted resync