### PR TITLE
fix:extend visibility timeout For resync indices

### DIFF
--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/GmcDoctorMessageListenerTest.java
@@ -24,10 +24,20 @@ package uk.nhs.hee.tis.revalidation.integration.sync.listener;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityResult;
+import io.awspring.cloud.messaging.listener.Visibility;
 import java.time.LocalDate;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,8 +47,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
 import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
-import uk.nhs.hee.tis.revalidation.integration.router.dto.RevalidationSummaryDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
+import uk.nhs.hee.tis.revalidation.integration.router.dto.RevalidationSummaryDto;
 import uk.nhs.hee.tis.revalidation.integration.router.message.payload.IndexSyncMessage;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.DoctorUpsertElasticSearchService;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.ElasticsearchIndexService;
@@ -57,6 +67,9 @@ class GmcDoctorMessageListenerTest {
   private DoctorUpsertElasticSearchService doctorUpsertElasticSearchService;
   @Mock
   private ElasticsearchIndexService elasticsearchIndexServiceMock;
+
+  @Mock
+  private Visibility visibilityMock;
 
   @BeforeEach
   void setUp() {
@@ -82,9 +95,12 @@ class GmcDoctorMessageListenerTest {
     message.setPayload(revalidationSummaryDto);
   }
 
+  @Mock
+  private Future<ChangeMessageVisibilityResult> futureMock;
+
   @Test
-  void testMessagesAreReceivedFromSqsQueue() {
-    gmcDoctorMessageListener.getMessage(message);
+  void testMessagesAreReceivedFromSqsQueue() throws Exception {
+    gmcDoctorMessageListener.getMessage(message, visibilityMock);
 
     ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = ArgumentCaptor
         .forClass(MasterDoctorView.class);
@@ -104,9 +120,36 @@ class GmcDoctorMessageListenerTest {
   void shouldNotThrowErrorWhenRecommendationReindexHasException() throws Exception {
     message.setSyncEnd(true);
 
+    doReturn(futureMock).when(visibilityMock).extend(anyInt());
+
     doThrow(Exception.class).when(elasticsearchIndexServiceMock)
         .resync("masterdoctorindex", "recommendationindex");
 
-    assertDoesNotThrow(() -> gmcDoctorMessageListener.getMessage(message));
+    assertDoesNotThrow(() -> gmcDoctorMessageListener.getMessage(message, visibilityMock));
+  }
+
+  @Test
+  void shouldNotResyncWhenExtendVisibilityThrowsExecutionException() throws Exception {
+    message.setSyncEnd(true);
+
+    doReturn(futureMock).when(visibilityMock).extend(anyInt());
+    doThrow(ExecutionException.class).when(futureMock).get();
+
+    assertDoesNotThrow(() -> gmcDoctorMessageListener.getMessage(message, visibilityMock));
+    verify(elasticsearchIndexServiceMock, never()).resync(anyString(), anyString());
+  }
+
+  @Test
+  void shouldNotResyncWhenExtendVisibilityThrowsInterruptedException() throws Exception {
+    message.setSyncEnd(true);
+    InterruptedException expectedException = new InterruptedException("expected");
+
+    doReturn(futureMock).when(visibilityMock).extend(anyInt());
+    doThrow(expectedException).when(futureMock).get();
+
+    var actual = assertThrows(InterruptedException.class,
+        () -> gmcDoctorMessageListener.getMessage(message, visibilityMock));
+    verify(elasticsearchIndexServiceMock, never()).resync(anyString(), anyString());
+    assertEquals(expectedException, actual);
   }
 }


### PR DESCRIPTION
When verifying the resync operation on Stage, I found the whole process was triggered 3 times by different ECS tasks, as shown below:
![image](https://user-images.githubusercontent.com/33690649/211617171-29d3753d-df80-4613-816f-4abf90c49aa9.png)
After the resync was done, we got 3 recommendationindex on ES:
![image](https://user-images.githubusercontent.com/33690649/211617869-a110d992-831a-487f-9642-36ffa5a8acbb.png) which caused triple records for every doctor on the UI.

From the logs, we can see the interval between each task is 30 seconds, which matches the config of visibilityTimout.
To solve this issue, we can extend the visibilityTimeout for this message.
Another option is to use FIFO queue.
Some explanations can be found here: https://stackoverflow.com/questions/30187683/aws-multiple-instances-reading-sqs

TIS21-3416