### PR TITLE
fix:tcsDBC when tcs exports null

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
@@ -57,6 +57,8 @@ public interface MasterDoctorViewMapper {
       nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   @Mapping(source = "programmeMembershipEndDate", target = "membershipEndDate",
       nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  @Mapping(source = "tcsDesignatedBody", target = "tcsDesignatedBody",
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   MasterDoctorView updateMasterDoctorView(ConnectionInfoDto source,
       @MappingTarget MasterDoctorView target);
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapperTest.java
@@ -191,5 +191,6 @@ class MasterDoctorViewMapperTest {
     assertThat(result.getMembershipStartDate(), nullValue());
     assertThat(result.getMembershipStartDate(), nullValue());
     assertThat(result.getMembershipEndDate(), nullValue());
+    assertThat(result.getTcsDesignatedBody(), nullValue());
   }
 }


### PR DESCRIPTION
When a doctor's current programme membership expires, tcs sends null to Reval, which should overwrites tcsDesignatedBody in Reval.

TIS21-3774