### PR TITLE
fix: allow null DBC from revalidation services for disconnected doctors

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/mapper/MasterDoctorViewMapper.java
@@ -33,9 +33,12 @@ import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 public interface MasterDoctorViewMapper {
 
   @Mapping(source = "doctorStatus", target = "tisStatus")
-  @Mapping(source = "designatedBodyCode", target = "designatedBody")
+  @Mapping(source = "designatedBodyCode", target = "designatedBody",
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   MasterDoctorView doctorToMasterView(DoctorsForDB cdcDoctor);
 
+  @Mapping(source = "designatedBody", target = "designatedBody",
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   MasterDoctorView updateMasterDoctorView(MasterDoctorView source,
       @MappingTarget MasterDoctorView target);
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
@@ -60,6 +60,7 @@ public class MasterDoctorView {
   private LocalDate submissionDate;
   private String programmeName;
   private String membershipType;
+  @Nullable
   private String designatedBody;
   private String gmcStatus;
   private RecommendationStatus tisStatus;
@@ -69,6 +70,7 @@ public class MasterDoctorView {
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private LocalDate lastUpdatedDate;
   private UnderNotice underNotice;
+  @Nullable
   private String tcsDesignatedBody;
   private String programmeOwner;
   @Nullable

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
@@ -59,7 +59,7 @@ class CdcDoctorServiceTest {
   MasterDoctorViewMapper mapper;
 
   @Captor
-  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = new ArgumentCaptor<MasterDoctorView>();
+  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor;
 
   private MasterDoctorView masterDoctorView = CdcTestDataGenerator.getTestMasterDoctorView();
 
@@ -98,7 +98,6 @@ class CdcDoctorServiceTest {
 
     verify(mapper).updateMasterDoctorView(existingDoctor, mapper.doctorToMasterView(newDoctor));
     verify(repository).save(masterDoctorViewCaptor.capture());
-
     assertNull(masterDoctorViewCaptor.getValue().getDesignatedBody());
   }
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
@@ -59,7 +59,7 @@ class CdcDoctorServiceTest {
   MasterDoctorViewMapper mapper;
 
   @Captor
-  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor;
+  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = new ArgummentCaptor<MasterDoctorView>();
 
   private MasterDoctorView masterDoctorView = CdcTestDataGenerator.getTestMasterDoctorView();
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
@@ -114,7 +114,6 @@ class CdcDoctorServiceTest {
     DoctorsForDB newDoctor = CdcTestDataGenerator.getCdcDoctorNullDbc();
     cdcDoctorService.upsertEntity(newDoctor);
 
-    verify(mapper).updateMasterDoctorView(mapper.doctorToMasterView(newDoctor), existingDoctor);
     verify(repository).save(masterDoctorViewCaptor.capture());
     assertNull(masterDoctorViewCaptor.getValue().getDesignatedBody());
   }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
@@ -21,9 +21,8 @@
 
 package uk.nhs.hee.tis.revalidation.integration.cdc.message.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -100,7 +99,7 @@ class CdcDoctorServiceTest {
     verify(mapper).updateMasterDoctorView(existingDoctor, mapper.doctorToMasterView(newDoctor));
     verify(repository).save(masterDoctorViewCaptor.capture());
 
-    assertThat(masterDoctorViewCaptor.getValue().getDesignatedBody(), isNull());
+    assertNull(masterDoctorViewCaptor.getValue().getDesignatedBody());
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcDoctorServiceTest.java
@@ -59,7 +59,7 @@ class CdcDoctorServiceTest {
   MasterDoctorViewMapper mapper;
 
   @Captor
-  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = new ArgummentCaptor<MasterDoctorView>();
+  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor = new ArgumentCaptor<MasterDoctorView>();
 
   private MasterDoctorView masterDoctorView = CdcTestDataGenerator.getTestMasterDoctorView();
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcTraineeUpdateServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/service/CdcTraineeUpdateServiceTest.java
@@ -124,7 +124,7 @@ class CdcTraineeUpdateServiceTest {
     assertThat(savedEntity.getGmcReferenceNumber(), is(masterDoctorView.getGmcReferenceNumber()));
     assertThat(savedEntity.getTisStatus(), is(masterDoctorView.getTisStatus()));
     assertThat(savedEntity.getAdmin(), is(masterDoctorView.getAdmin()));
-
+    assertThat(savedEntity.getDesignatedBody(), is(masterDoctorView.getDesignatedBody()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -71,6 +71,20 @@ public class CdcTestDataGenerator {
       .existsInGmc(EXISTS_IN_GMC_VAL)
       .build();
 
+  private static DoctorsForDB doctorsForDBNullDbc = DoctorsForDB.builder()
+      .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+      .doctorFirstName(DOCTOR_FIRST_NAME_VAL)
+      .doctorFirstName(DOCTOR_LAST_NAME_VAL)
+      .submissionDate(LocalDate.now())
+      .dateAdded(LocalDate.now())
+      .underNotice(UNDER_NOTICE_VAL)
+      .sanction(SANCTION_VAL)
+      .doctorStatus(DOCTOR_STATUS_VAL)
+      .lastUpdatedDate(LocalDate.now())
+      .admin(ADMIN_VAL)
+      .existsInGmc(EXISTS_IN_GMC_VAL)
+      .build();
+
   private static Recommendation recommendation = Recommendation.builder()
       .id("1")
       .gmcNumber(GMC_REFERENCE_NUMBER_VAL)
@@ -109,6 +123,16 @@ public class CdcTestDataGenerator {
   public static CdcDocumentDto<DoctorsForDB> getCdcDoctorInsertCdcDocumentDto() {
     return new CdcDocumentDto<DoctorsForDB>(OperationType.INSERT.getValue(), doctorsForDB);
   }
+
+  /**
+   * Get a test instance of an insert DoctorsForDb CdcDocumentDto with a null designated body code.
+   *
+   * @return CdcDocumentDto CdcDoctor test instance
+   */
+  public static CdcDocumentDto<DoctorsForDB> getCdcDoctorNullDbcInsertCdcDocumentDto() {
+    return new CdcDocumentDto<DoctorsForDB>(OperationType.INSERT.getValue(), doctorsForDBNullDbc);
+  }
+
 
   /**
    * Get a test instance of an replace DoctorsForDb CdcDocumentDto.

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -74,7 +74,7 @@ public class CdcTestDataGenerator {
   private static DoctorsForDB doctorsForDBNullDbc = DoctorsForDB.builder()
       .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
       .doctorFirstName(DOCTOR_FIRST_NAME_VAL)
-      .doctorFirstName(DOCTOR_LAST_NAME_VAL)
+      .doctorLastName(DOCTOR_LAST_NAME_VAL)
       .submissionDate(LocalDate.now())
       .dateAdded(LocalDate.now())
       .underNotice(UNDER_NOTICE_VAL)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -59,7 +59,7 @@ public class CdcTestDataGenerator {
   private static DoctorsForDB doctorsForDB = DoctorsForDB.builder()
       .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
       .doctorFirstName(DOCTOR_FIRST_NAME_VAL)
-      .doctorFirstName(DOCTOR_LAST_NAME_VAL)
+      .doctorLastName(DOCTOR_LAST_NAME_VAL)
       .submissionDate(LocalDate.now())
       .dateAdded(LocalDate.now())
       .underNotice(UNDER_NOTICE_VAL)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -233,7 +233,7 @@ public class CdcTestDataGenerator {
   /**
    * Get a test instance of an insert DoctorsForDb.
    *
-   * @return CdcDocumentDto CdcDoctor test instance
+   * @return DoctorsForDB test instance
    */
   public static DoctorsForDB getCdcDoctor() {
     return doctorsForDB;
@@ -242,7 +242,7 @@ public class CdcTestDataGenerator {
   /**
    * Get a test instance of a DoctorsForDb Object with a null designated body code.
    *
-   * @return DoctorsForDB doctorsForDBNullDbc test instance
+   * @return DoctorsForDB null DBC test instance
    */
   public static DoctorsForDB getCdcDoctorNullDbc() {
     return doctorsForDBNullDbc;

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -125,16 +125,6 @@ public class CdcTestDataGenerator {
   }
 
   /**
-   * Get a test instance of an insert DoctorsForDb CdcDocumentDto with a null designated body code.
-   *
-   * @return CdcDocumentDto CdcDoctor test instance
-   */
-  public static CdcDocumentDto<DoctorsForDB> getCdcDoctorNullDbcInsertCdcDocumentDto() {
-    return new CdcDocumentDto<DoctorsForDB>(OperationType.INSERT.getValue(), doctorsForDBNullDbc);
-  }
-
-
-  /**
    * Get a test instance of an replace DoctorsForDb CdcDocumentDto.
    *
    * @return CdcDocumentDto CdcDoctor test instance
@@ -142,6 +132,8 @@ public class CdcTestDataGenerator {
   public static CdcDocumentDto<DoctorsForDB> getCdcDoctorReplaceCdcDocumentDto() {
     return new CdcDocumentDto<DoctorsForDB>(OperationType.REPLACE.getValue(), doctorsForDB);
   }
+
+
 
   /**
    * Get a test instance of an insert CdcRecommendation CdcDocumentDto.
@@ -238,5 +230,23 @@ public class CdcTestDataGenerator {
         .programmeMembershipEndDate(LocalDate.now().plusYears(3L).plusMonths(3))
         .curriculumEndDate(LocalDate.now().plusYears(3L))
         .build();
+  }
+
+  /**
+   * Get a test instance of an insert DoctorsForDb.
+   *
+   * @return CdcDocumentDto CdcDoctor test instance
+   */
+  public static DoctorsForDB getCdcDoctor() {
+    return doctorsForDB;
+  }
+
+  /**
+   * Get a test instance of a DoctorsForDb Object with a null designated body code.
+   *
+   * @return DoctorsForDB doctorsForDBNullDbc test instance
+   */
+  public static DoctorsForDB getCdcDoctorNullDbc() {
+    return doctorsForDBNullDbc;
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -133,8 +133,6 @@ public class CdcTestDataGenerator {
     return new CdcDocumentDto<DoctorsForDB>(OperationType.REPLACE.getValue(), doctorsForDB);
   }
 
-
-
   /**
    * Get a test instance of an insert CdcRecommendation CdcDocumentDto.
    *


### PR DESCRIPTION
TIS21-4510: Connections Discrepnacies Data Cleanup: Remove last- prefix from disconnected DBCs