### PR TITLE
fix: restore mapping from previous index during ES resync

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/message/SyncStartHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/message/SyncStartHandler.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.revalidation.integration.router.message;
 
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Handler;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -46,7 +47,7 @@ public class SyncStartHandler {
   DoctorUpsertElasticSearchService doctorUpsertElasticSearchService;
 
   @Handler
-  public void startTraineeSync() {
+  public void startTraineeSync() throws IOException {
     log.info("Elastic Search update sync start.");
     doctorUpsertElasticSearchService.clearMasterDoctorIndex();
     rabbitTemplate.convertAndSend(revalExchange, revalSyncStartRoutingKey, "syncStart");

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
@@ -24,6 +24,8 @@ package uk.nhs.hee.tis.revalidation.integration.sync.service;
 import java.io.IOException;
 import java.util.ArrayList;
 import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.client.indices.GetIndexResponse;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
@@ -130,9 +132,10 @@ public class DoctorUpsertElasticSearchService {
   /**
    * Clear all records in masterdoctorindex by deleting and recreating the index.
    */
-  public void clearMasterDoctorIndex() {
+  public void clearMasterDoctorIndex() throws IOException {
+    MappingMetadata mapping = elasticsearchIndexHelper.getMapping(ES_INDEX);
     deleteMasterDoctorIndex();
-    createMasterDoctorIndex();
+    createMasterDoctorIndex(mapping);
     addAliasToMasterDoctorIndex();
   }
 
@@ -145,11 +148,9 @@ public class DoctorUpsertElasticSearchService {
     }
   }
 
-  private void createMasterDoctorIndex() {
+  private void createMasterDoctorIndex(MappingMetadata mapping) throws IOException {
     log.info("creating and updating mappings");
-    elasticSearchOperations.indexOps(IndexCoordinates.of(ES_INDEX)).create();
-    elasticSearchOperations.indexOps(IndexCoordinates.of(ES_INDEX))
-        .putMapping(MasterDoctorView.class);
+    elasticsearchIndexHelper.createIndex(ES_INDEX, mapping);
   }
 
   private void addAliasToMasterDoctorIndex() {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -113,7 +113,7 @@ class DoctorUpsertElasticSearchServiceTest {
   }
 
   @Test
-  void shouldDeleteAndAddIndexWithMappings() {
+  void shouldDeleteAndAddIndexWithMappings() throws IOException {
     when(elasticsearchOperations.indexOps(indexCaptor.capture())).thenReturn(indexOperations);
     service.clearMasterDoctorIndex();
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -101,7 +101,7 @@ class DoctorUpsertElasticSearchServiceTest {
   }
 
   @Test
-  void shouldIgnoreNotFoundOnDelete(){
+  void shouldIgnoreNotFoundOnDelete() {
     IndexNotFoundException expectedException = new IndexNotFoundException("expected");
     when(elasticsearchOperations.indexOps((IndexCoordinates) any()))
         .thenThrow(new IndexNotFoundException("Index"))


### PR DESCRIPTION
TIS21-4554: Should ignore case when searching for doctors in Connections summary