### PR TITLE
chore:upgrade Camel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ dependencies {
     exclude group: "org.junit.vintage", module: "junit-vintage-engine"
   }
 
-  // Apache Camel starters
-  ext.camelVersion = "3.6.0"
-  implementation "org.apache.camel.springboot:camel-spring-boot-starter:$camelVersion"
-  implementation "org.apache.camel.springboot:camel-http-starter:$camelVersion"
-  implementation "org.apache.camel.springboot:camel-servlet-starter:$camelVersion"
-  implementation "org.apache.camel.springboot:camel-jackson-starter:$camelVersion"
+  // Apache Camel
+  implementation platform('org.apache.camel.springboot:camel-spring-boot-bom:3.20.5')
+  implementation "org.apache.camel.springboot:camel-spring-boot-starter"
+  implementation "org.apache.camel.springboot:camel-http-starter"
+  implementation "org.apache.camel.springboot:camel-servlet-starter"
+  implementation "org.apache.camel.springboot:camel-jackson-starter"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,10 +10,9 @@ spring:
     ssl.enabled: ${RABBITMQ_USE_SSL:false}
 
 camel:
-  component:
-    servlet:
-      mapping:
-        context-path: /api/*
+  servlet:
+    mapping:
+      context-path: /api/*
 
 server:
   port: 8088


### PR DESCRIPTION
1. update camel to use bom and upgrade to 3.20.5
2. after version upgrade, all rest api didn't work (404) and finally found it was the context-path which needed an update.

TIS21-4548