### PR TITLE
chore:config for ObjectMapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
 
   // Keycloak
   implementation "com.transformuk.hee:keycloak-client:3.0.0"
-  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0"
 
   //RabbitMQ
   implementation "org.springframework.boot:spring-boot-starter-amqp"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ camel:
   servlet:
     mapping:
       context-path: /api/*
+  dataformat:
+    jackson:
+      # added when upgrade Camel to 3.20.5, otherwise the object mapper can not be found.
+      # setting it to true with multiple object mappers can lead to unpredictable behaviors.
+      auto-discover-object-mapper: true
 
 server:
   port: 8088


### PR DESCRIPTION
- camel.dataformat.jackson.auto-discover-objectj-mapper: true
- delete the duplicate dependency.

TIS21-4548