### PR TITLE
fix:getRecommendationByGmcId

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/processor/GmcIdProcessorBean.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/processor/GmcIdProcessorBean.java
@@ -27,14 +27,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import javax.swing.event.ListDataEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import uk.nhs.hee.tis.revalidation.integration.router.dto.ExceptionResponseDto;
-import uk.nhs.hee.tis.revalidation.integration.router.dto.TraineeRecommendationDto;
 import uk.nhs.hee.tis.revalidation.integration.router.dto.TraineeSummaryDto;
 
 @Slf4j
@@ -53,13 +51,6 @@ public class GmcIdProcessorBean {
     }
     return List.of();
 
-  }
-
-  public String getGmcIdOfRecommendationTrainee(final Exchange exchange)
-      throws JsonProcessingException {
-    final var body = exchange.getIn().getBody();
-    final var traineeRecommendationDto = mapper.convertValue(body, TraineeRecommendationDto.class);
-    return traineeRecommendationDto.getGmcNumber();
   }
 
   public List<String> getConnectionExceptionGmcIds(final Exchange exchange)

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
@@ -89,12 +89,11 @@ public class RecommendationServiceRouter extends RouteBuilder {
 
     from("direct:recommendation-gmc-id")
         .to("direct:recommendation-trainee-by-gmc-id")
-        .setHeader("gmcIds").method(gmcIdProcessorBean, "getGmcIdOfRecommendationTrainee")
+        .setHeader("gmcIds").simple("${header.gmcId}")
         .enrich("direct:tcs-trainees", doctorRecommendationAggregationStrategy);
 
     from("direct:recommendation-trainee-by-gmc-id")
-        .toD(serviceUrl + "/api/recommendation/${header.gmcId}?bridgeEndpoint=true")
-        .unmarshal().json(JsonLibrary.Jackson);
+        .toD(serviceUrl + "/api/recommendation/${header.gmcId}?bridgeEndpoint=true");
 
     from("direct:recommendation-submit")
         .to("direct:reval-officer")


### PR DESCRIPTION
Problem to resolve:
For getRecommendationByGmcId endpoint in Recommendation service, when there's no doctor record found in `doctorsForDB` collection, Recommendation service returns a null body. But in the router, `unmarshal` can't handle the null body, so it throws an exception `com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input`, so a 500 will be returned from Camel to the frontend, see: https://stage-revalidation.tis.nhs.uk/recommendation/7560496.

Change:
1. remove marshal from the router, and do deserialisation manually in the aggregator. (It's not possible to add try catch block around a marshal operation).
3. when the message body from Recommendation service is null, return a 404 not found error to frontend.

TIS21-4548