### PR TITLE
feat: add XRay tracing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id "java"
-  id "org.springframework.boot" version "2.5.5"
+  id "org.springframework.boot" version "2.5.6"
   id "io.spring.dependency-management" version "1.0.11.RELEASE"
 
   // Code quality plugins
@@ -11,7 +11,7 @@ plugins {
 
 group = "uk.nhs.hee.tis.revalidation"
 version = "0.4.2"
-sourceCompatibility = "11"
+sourceCompatibility = "17"
 
 configurations {
   compileOnly {
@@ -46,6 +46,7 @@ dependencies {
   implementation "org.apache.camel.springboot:camel-http-starter"
   implementation "org.apache.camel.springboot:camel-servlet-starter"
   implementation "org.apache.camel.springboot:camel-jackson-starter"
+  implementation "org.apache.camel.springboot:camel-aws-xray-starter"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"
@@ -73,7 +74,7 @@ dependencies {
   implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging:$cloudVersion"
 
   // Elastic Search
-  implementation "org.springframework.boot:spring-boot-starter-data-elasticsearch:2.5.6"
+  implementation "org.springframework.boot:spring-boot-starter-data-elasticsearch"
 
   // Java Persistence
   implementation "javax.persistence:javax.persistence-api:2.2"

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListener.java
@@ -38,9 +38,9 @@ import uk.nhs.hee.tis.revalidation.integration.entity.Recommendation;
 @Component
 public class CdcSqsMessageListener {
 
-  private CdcRecommendationMessageHandler cdcRecommendationMessageHandler;
-  private CdcDoctorMessageHandler cdcDoctorMessageHandler;
-  private ObjectMapper mapper;
+  private final CdcRecommendationMessageHandler cdcRecommendationMessageHandler;
+  private final CdcDoctorMessageHandler cdcDoctorMessageHandler;
+  private final ObjectMapper mapper;
 
   /**
    * Create a Listener.
@@ -70,8 +70,7 @@ public class CdcSqsMessageListener {
   public void getRecommendationMessage(String message) throws IOException {
     try {
       CdcDocumentDto<Recommendation> cdcDocument =
-          mapper.readValue(message, new TypeReference<CdcDocumentDto<Recommendation>>() {
-          });
+          mapper.readValue(message, new TypeReference<>() {});
       cdcRecommendationMessageHandler.handleMessage(cdcDocument);
     } catch (OperationNotSupportedException e) {
       log.error(e.getMessage(), e);
@@ -87,8 +86,7 @@ public class CdcSqsMessageListener {
   public void getDoctorMessage(String message) throws IOException {
     try {
       CdcDocumentDto<DoctorsForDB> cdcDocument =
-          mapper.readValue(message, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
-          });
+          mapper.readValue(message, new TypeReference<>() {});
       cdcDoctorMessageHandler.handleMessage(cdcDocument);
     } catch (OperationNotSupportedException e) {
       log.error(e.getMessage(), e);

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/config/AwsConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/config/AwsConfig.java
@@ -21,29 +21,33 @@
 
 package uk.nhs.hee.tis.revalidation.integration.config;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import org.apache.camel.component.aws.xray.EIPTracingStrategy;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+@Configuration
+public class AwsConfig {
 
-class AwsSqsQueueConfigTest {
-
-  private AwsSqsQueueConfig awsSqsQueueConfig;
-
-  @BeforeEach
-  void setUp() {
-    awsSqsQueueConfig = new AwsSqsQueueConfig();
+  @Bean
+  public QueueMessagingTemplate queueMessagingTemplate() {
+    return new QueueMessagingTemplate(amazonSQSAsync());
   }
 
-  @Test
-  public void testAmazonSqsAsync() {
-    assertThat(awsSqsQueueConfig.amazonSQSAsync(), notNullValue());
+  @Primary
+  @Bean
+  public AmazonSQSAsync amazonSQSAsync() {
+    return AmazonSQSAsyncClientBuilder.defaultClient();
   }
 
-  @Test
-  public void testQueueMessagingTemplate() {
-    assertThat(awsSqsQueueConfig.queueMessagingTemplate(), notNullValue());
+  @Bean
+  public XRayTracer awsXrayTracer() {
+    XRayTracer tracer = new XRayTracer();
+    tracer.setTracingStrategy(new EIPTracingStrategy());
+    return tracer;
   }
 }
-

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/config/AwsConfigTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/config/AwsConfigTest.java
@@ -21,25 +21,43 @@
 
 package uk.nhs.hee.tis.revalidation.integration.config;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.apache.camel.component.aws.xray.EIPTracingStrategy;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Configuration
-public class AwsSqsQueueConfig {
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {AwsConfig.class})
+class AwsConfigTest {
+  @Autowired
+  ApplicationContext ctx;
 
-  @Bean
-  public QueueMessagingTemplate queueMessagingTemplate() {
-    return new QueueMessagingTemplate(amazonSQSAsync());
+  @Test
+  void testAmazonSqsAsync() {
+    assertThat(ctx.getBean(AmazonSQSAsync.class), notNullValue());
   }
 
-  @Primary
-  @Bean
-  public AmazonSQSAsync amazonSQSAsync() {
-    return AmazonSQSAsyncClientBuilder.defaultClient();
+  @Test
+  void testQueueMessagingTemplate() {
+    assertThat(ctx.getBean(QueueMessagingTemplate.class), notNullValue());
+  }
+
+  @Test
+  void testXrayTracerCreated() {
+    XRayTracer actual = ctx.getBean(XRayTracer.class);
+    assertThat(actual, notNullValue());
+    assertTrue(actual.getTracingStrategy() instanceof EIPTracingStrategy);
   }
 
 }
+


### PR DESCRIPTION
Some requests in Revalidation can become slow.
It is not clear why or when.
TIS21-4956 addressed the Reval Sync bottleneck (AWS Lambda). X-Ray helped to identify the bottleneck.

We may need `aws-xray-recorder-sdk-spring` for `@XRayEnabled` routers.

test: AWS config checks from Context

This seems like a more appropriate test.

chore: clean line endings and use of Spring BOM

NO-CARD: Shaving off TIS21-4956 Reval Sync Issues