### PR TITLE
chore(deps): build on Java 17

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cache: gradle
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -57,7 +57,7 @@ jobs:
         with:
           cache: gradle
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -90,7 +90,7 @@ jobs:
         with:
           cache: gradle
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -130,7 +130,7 @@ jobs:
         with:
           cache: gradle
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Java 11 is deprecated for analysis and project can be built with 17 too

NO-CARD: Shaving off TIS21-4956 Reval Sync Issues