### PR TITLE
build: verified deployed task definition

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -232,12 +232,24 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ github.sha }}
 
       - name: Deploy Amazon ECS task definition
+        id: ecs-deploy
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ github.event.repository.name }}
           cluster: revalidation-preprod
           wait-for-service-stability: true
+
+      - name: Verify ECS deployment
+        run: |
+          CURRENT_TASK_DEF_ARN=$(aws ecs describe-services --cluster revalidation-preprod --service ${{ github.event.repository.name }} --query services[0].deployments[0].taskDefinition | jq -r ".")
+          NEW_TASK_DEF_ARN=${{ steps.ecs-deploy.outputs.task-definition-arn }}
+          echo "Current task arn: $CURRENT_TASK_DEF_ARN"
+          echo "New task arn: $NEW_TASK_DEF_ARN"
+          if [ "$CURRENT_TASK_DEF_ARN" != "$NEW_TASK_DEF_ARN" ]; then
+            echo "Deployment failed."
+            exit 1
+          fi
 
       - name: Push stable tag image to Amazon ECR
         env:


### PR DESCRIPTION
Triggering an ECS deployment circuit breaker can cause a false positive when waiting for service stability.

Add a post-deployment verification step to check the task def ARN against the expectation.

TIS21-4819
TIS21-5332