### PR TITLE
fix: update regex returned by the ReST service

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
@@ -109,7 +109,7 @@ public class RecommendationServiceRouter extends RouteBuilder {
     from("direct:recommendation-summary")
         .to(serviceUrl + "/api/v1/doctors?bridgeEndpoint=true")
         .transform(
-            body().regexReplaceAll("\\\"traineeInfo\\\" \\:", "\\\"recommendationInfo\\\" \\:"))
+            body().regexReplaceAll("\\\"traineeInfo\\\"\\s?\\:", "\\\"recommendationInfo\\\" \\:"))
         .unmarshal().json(JsonLibrary.Jackson);
 
     from("direct:doctors-autocomplete")

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/router/service/RecommendationServiceRouter.java
@@ -109,7 +109,7 @@ public class RecommendationServiceRouter extends RouteBuilder {
     from("direct:recommendation-summary")
         .to(serviceUrl + "/api/v1/doctors?bridgeEndpoint=true")
         .transform(
-            body().regexReplaceAll("\\\"traineeInfo\\\"\\:", "\\\"recommendationInfo\\\"\\:"))
+            body().regexReplaceAll("\\\"traineeInfo\\\" \\:", "\\\"recommendationInfo\\\" \\:"))
         .unmarshal().json(JsonLibrary.Jackson);
 
     from("direct:doctors-autocomplete")


### PR DESCRIPTION
The ReST service was updated to indent json responses. As well as indents, the "pretty" format has a space after field names.

TIS21-5504: Unscheduled prod updates