### PR TITLE
fix: use unique names in different steps

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-jar
+          name: app-jar-${{ github.run_id }}
           path: build/libs/*.jar
 
   check:
@@ -74,7 +74,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: reports
+          name: reports-check-${{ github.run_id }}
           path: build/reports
 
   test:
@@ -107,7 +107,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: reports
+          name: reports-test-${{ github.run_id }}
           path: build/reports
 
   analyze:
@@ -122,7 +122,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: reports
+          name: reports-check-${{ github.run_id }}
           path: build/reports
 
       - name: Set up JDK
@@ -182,7 +182,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: app-jar
+          name: app-jar-${{ github.run_id }}
           path: build/libs
 
       - name: Configure AWS credentials


### PR DESCRIPTION
In workflow V3, if you uploaded an artifact with the same name multiple times, GitHub Actions would just overwrite or merge the content without telling us.

However, in V4 behaviour they made it stricter. Now, if you try to upload an artifact with a name already used in the same workflow run, it throws a 409 Conflict error. So it is required to use unique names in different steps.

TIS21-7168