### PR TITLE
fix: add filter as top level key to the json

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
@@ -42,8 +42,10 @@ public class DoctorUpsertElasticSearchService {
   protected static final String ES_DISCREPANCIES_FILTER =
       """
          {
-           "script": {
-              "script": "doc['tcsDesignatedBody.keyword'] != doc['designatedBody.keyword']"
+           "filter": {
+             "script": {
+               "script": "doc['tcsDesignatedBody.keyword'] != doc['designatedBody.keyword']"
+             }
            }
          }
       """;


### PR DESCRIPTION
"filter" : {} is needed as top level key which will enclose the "script" block. It has been tested as below:
With filter key: alias is created without any error

![image](https://github.com/user-attachments/assets/f61d1cf2-af03-4b4a-bb03-0ebdef6ddce6)

Without filter key: parse exception is thrown
![image](https://github.com/user-attachments/assets/5c753b9b-c9e3-45b8-b85d-28e84bb59b18)

Hopefully this will fix the issue in the code level.

TIS21-7021