### PR TITLE
fix: handle date format change

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
@@ -41,6 +41,7 @@ public abstract class CdcMessageHandler<T> implements MessageHandler<CdcDocument
     switch (operation) {
       case INSERT:
       case REPLACE:
+      case UPDATE:
         cdcService.upsertEntity(message.getFullDocument());
         break;
       default:

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
@@ -27,6 +27,11 @@ import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcService;
 import uk.nhs.hee.tis.revalidation.integration.message.MessageHandler;
 
+/**
+ * An abstract class to handle cdc messages.
+ *
+ * @param <T> the message type
+ */
 public abstract class CdcMessageHandler<T> implements MessageHandler<CdcDocumentDto<T>> {
 
   CdcService<T> cdcService;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
@@ -39,9 +39,7 @@ public abstract class CdcMessageHandler<T> implements MessageHandler<CdcDocument
   public void handleMessage(CdcDocumentDto<T> message) throws OperationNotSupportedException {
     final OperationType operation = OperationType.valueOf(message.getOperationType().toUpperCase());
     switch (operation) {
-      case INSERT:
-      case REPLACE:
-      case UPDATE:
+      case INSERT, REPLACE, UPDATE:
         cdcService.upsertEntity(message.getFullDocument());
         break;
       default:

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
@@ -28,21 +28,20 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 public class CdcDateDeserializer extends JsonDeserializer<LocalDate> {
 
-  private static final java.time.format.DateTimeFormatter CDC_DATE_FORMAT =
+  private static final DateTimeFormatter CDC_DATE_FORMAT =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
   private final LocalDateDeserializer localDateDeserializer;
 
   public CdcDateDeserializer() {
-    this.localDateDeserializer = new LocalDateDeserializer(DateTimeFormatter.ISO_LOCAL_DATE);
+    this.localDateDeserializer = new LocalDateDeserializer(DateTimeFormatter.ISO_DATE);
   }
 
   @Override
@@ -54,8 +53,7 @@ public class CdcDateDeserializer extends JsonDeserializer<LocalDate> {
       if (token == JsonToken.START_OBJECT) {
         JsonNode node = p.readValueAsTree();
         String dateStr = node.get("$date").asText();
-        Instant instant = Instant.parse(dateStr);
-        return instant.atZone(ZoneOffset.UTC).toLocalDate();
+        return OffsetDateTime.parse(dateStr).toLocalDate();
       } else {
         String dateStr = p.getText();
         return LocalDate.parse(dateStr, CDC_DATE_FORMAT);

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.revalidation.integration.cdc.message.util;
 
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -29,10 +31,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
+/**
+ * Date deserializer for deserializing dates for cdc messages.
+ */
 public class CdcDateDeserializer extends JsonDeserializer<LocalDate> {
 
   private static final DateTimeFormatter CDC_DATE_FORMAT =
@@ -53,7 +57,7 @@ public class CdcDateDeserializer extends JsonDeserializer<LocalDate> {
       if (token == JsonToken.START_OBJECT) {
         JsonNode node = p.readValueAsTree();
         String dateStr = node.get("$date").asText();
-        return OffsetDateTime.parse(dateStr).toLocalDate();
+        return LocalDate.parse(dateStr, ISO_DATE_TIME);
       } else {
         String dateStr = p.getText();
         return LocalDate.parse(dateStr, CDC_DATE_FORMAT);

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializer.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
@@ -25,13 +25,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
 import javax.naming.OperationNotSupportedException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.testutil.CdcTestDataGenerator;
 import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcDoctorService;
+import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
+
+import java.util.Arrays;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class CdcDoctorMessageHandlerTest {
@@ -50,17 +58,17 @@ class CdcDoctorMessageHandlerTest {
         () -> cdcDoctorMessageHandler.handleMessage(testMessage));
   }
 
-  @Test
-  void shouldHandleInserts() throws OperationNotSupportedException {
-    var testMessage = CdcTestDataGenerator.getCdcDoctorInsertCdcDocumentDto();
-    cdcDoctorMessageHandler.handleMessage(testMessage);
-
-    verify(cdcDoctorService).upsertEntity(testMessage.getFullDocument());
+  private static List<CdcDocumentDto<DoctorsForDB>> cdcDtos() {
+    return Arrays.asList(
+        CdcTestDataGenerator.getCdcDoctorUpdateCdcDocumentDto(),
+        CdcTestDataGenerator.getCdcDoctorInsertCdcDocumentDto(),
+        CdcTestDataGenerator.getCdcDoctorReplaceCdcDocumentDto());
   }
 
-  @Test
-  void shouldHandleReplace() throws OperationNotSupportedException {
-    var testMessage = CdcTestDataGenerator.getCdcDoctorReplaceCdcDocumentDto();
+  @ParameterizedTest
+  @MethodSource("cdcDtos")
+  void shouldHandleDifferentOperationTypes() throws OperationNotSupportedException {
+    var testMessage = CdcTestDataGenerator.getCdcDoctorInsertCdcDocumentDto();
     cdcDoctorMessageHandler.handleMessage(testMessage);
 
     verify(cdcDoctorService).upsertEntity(testMessage.getFullDocument());

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
@@ -25,7 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
 import javax.naming.OperationNotSupportedException;
-
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,10 +34,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Arrays;
-import java.util.List;
-
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.testutil.CdcTestDataGenerator;
 import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcDoctorService;

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
@@ -33,13 +33,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.testutil.CdcTestDataGenerator;
 import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcDoctorService;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
-
-import java.util.Arrays;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class CdcDoctorMessageHandlerTest {
@@ -51,8 +52,7 @@ class CdcDoctorMessageHandlerTest {
   CdcDoctorService cdcDoctorService;
 
   @Test
-  void shouldRejectOtherDoctorOperationMessageFromSqsQueueToHandler()
-      throws OperationNotSupportedException {
+  void shouldRejectOtherDoctorOperationMessageFromSqsQueueToHandler() {
     var testMessage = CdcTestDataGenerator.getCdcDoctorUnsupportedCdcDocumentDto();
     assertThrows(OperationNotSupportedException.class,
         () -> cdcDoctorMessageHandler.handleMessage(testMessage));

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcDoctorMessageHandlerTest.java
@@ -24,9 +24,9 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.message.handler;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
-import javax.naming.OperationNotSupportedException;
 import java.util.Arrays;
 import java.util.List;
+import javax.naming.OperationNotSupportedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -85,15 +85,6 @@ public class CdcTestDataGenerator {
       .existsInGmc(EXISTS_IN_GMC_VAL)
       .build();
 
-  private static Recommendation recommendation = Recommendation.builder()
-      .id("1")
-      .gmcNumber(GMC_REFERENCE_NUMBER_VAL)
-      .recommendationType(RecommendationType.REVALIDATE)
-      .recommendationStatus(DRAFT)
-      .gmcSubmissionDate(LocalDate.now().plusMonths(6))
-      .admin(ADMIN_VAL)
-      .build();
-
   /**
    * Get a test instance of MasterDoctorView.
    *
@@ -204,9 +195,9 @@ public class CdcTestDataGenerator {
    * @return CdcDocumentDto CdcDoctor unsupported test instance
    */
   public static CdcDocumentDto<DoctorsForDB> getCdcDoctorUnsupportedCdcDocumentDto() {
-    DoctorsForDB doctorsForDB = DoctorsForDB.builder().build();
+    DoctorsForDB doctorsForDb = DoctorsForDB.builder().build();
 
-    return new CdcDocumentDto<DoctorsForDB>(OperationType.DROP.getValue(), doctorsForDB);
+    return new CdcDocumentDto<DoctorsForDB>(OperationType.DROP.getValue(), doctorsForDb);
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -134,6 +134,15 @@ public class CdcTestDataGenerator {
   }
 
   /**
+   * Get a test instance of an update DoctorsForDb CdcDocumentDto.
+   *
+   * @return CdcDocumentDto CdcDoctor test instance
+   */
+  public static CdcDocumentDto<DoctorsForDB> getCdcDoctorUpdateCdcDocumentDto() {
+    return new CdcDocumentDto<DoctorsForDB>(OperationType.UPDATE.getValue(), doctorsForDB);
+  }
+
+  /**
    * Get a test instance of an insert CdcRecommendation CdcDocumentDto.
    *
    * @return CdcDocumentDto CdcRecommendation insert test instance

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -39,6 +39,9 @@ import uk.nhs.hee.tis.revalidation.integration.enums.RecommendationGmcOutcome;
 import uk.nhs.hee.tis.revalidation.integration.enums.RecommendationType;
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 
+/**
+ * The utility class to help generate test data.
+ */
 @Component
 public class CdcTestDataGenerator {
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
@@ -3,6 +3,7 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.message.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import java.time.LocalDate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,8 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.RevalidationIntegrationApplication;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
-
-import java.time.LocalDate;
 
 @ExtendWith(MockitoExtension.class)
 class CdcDateDeserializerTest {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
@@ -2,15 +2,11 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.message.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -131,15 +127,5 @@ class CdcDateDeserializerTest {
     assertThat(dateAdded.getDayOfMonth(), is(7));
     assertThat(dateAdded.getMonthValue(), is(10));
     assertThat(dateAdded.getYear(), is(2015));
-  }
-
-  @Test
-  void shouldThrowErrorWhenDateInvalid() {
-    JsonMappingException thrown = assertThrows(JsonMappingException.class, () ->
-        mapper.readValue(CDC_DOCDB_EVENT_JSON_DATE_INVALID, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
-            }
-        ), "Expected JsonMappingException to throw, but it didn't");
-
-    assertTrue(thrown.getMessage().contains("Not supported date format:"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
@@ -3,10 +3,10 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.message.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import java.time.LocalDate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -15,6 +16,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.RevalidationIntegrationApplication;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.integration.entity.Recommendation;
+import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
+import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
 
 @ExtendWith(MockitoExtension.class)
 class CdcDateDeserializerTest {
@@ -42,28 +46,6 @@ class CdcDateDeserializerTest {
           }
           """;
 
-  private static final String CDC_DOCDB_JSON_GMC_NUMBER =
-      """
-          {
-            "gmcReferenceNumber":{"_data":"01625a0706000001c001000001c000020042"},
-            "operationType":"replace",
-            "clusterTime":"Timestamp(1650067206, 448)",
-            "ns":{"db":"revalidation","coll":"doctorsForDB"},
-            "documentKey":{"_id":"1234567"},
-            "fullDocument":{
-                              "_id":"1234567","doctorFirstName":"First",
-                              "doctorLastName":"Last",
-                              "submissionDate":"2017-10-19 00:00:00",
-                              "dateAdded":"2015-10-07 00:00:00",
-                              "underNotice":"NO","sanction":"No",
-                              "doctorStatus":"COMPLETED",
-                              "lastUpdatedDate":"2022-04-15 00:00:00",
-                              "designatedBodyCode":"1-AIIDWI",
-                              "existsInGmc":false,
-                              "_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}}
-          """;
-
-
   private static final String CDC_DOCDB_EVENT_JSON =
       """
           {
@@ -73,11 +55,11 @@ class CdcDateDeserializerTest {
             "fullDocument": {
                               "_id": "1234567", "doctorFirstName": "AAA", "doctorLastName": "BBB",
                               "submissionDate": {"$date": "2024-08-05T00:00:00Z"},
-                              "dateAdded": {"$date": "2015-10-07T00:00:00Z"}, "underNotice": "YES",
+                              "dateAdded": {"$date": "2015-10-07T00:00:00Z"}, "underNotice": "NO",
                               "sanction": "No", "doctorStatus": "DRAFT",
                               "lastUpdatedDate": {"$date": "2025-04-29T00:00:00Z"},
                               "gmcLastUpdatedDateTime": {"$date": "2025-04-29T00:00:54.956Z"},
-                              "designatedBodyCode": "1-1RSSQ05", "existsInGmc": true,
+                              "designatedBodyCode": "1-1RSSQ05", "existsInGmc": false,
                               "_class": "uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"},
             "ns": {"db": "revalidation", "coll": "doctorsForDB"},
             "operationType": "update",
@@ -86,7 +68,24 @@ class CdcDateDeserializerTest {
           }
           """;
 
-  private String gmcId = "1234567";
+  private static final String CDC_RECOMMENDATION_EVENT_JSON =
+      """
+          {
+            "_id": {"_data": "0168220a440000000b01000000000002d1b5"},
+            "clusterTime": {"$timestamp": {"t": 1747061316, "i": 11}},
+            "documentKey": {"_id": {"$oid": "67fcf9ea74f4e44093b9f327"}},
+            "fullDocument": {
+                              "_id": {"$oid": "67fcf9ea74f4e44093b9f327"},
+                              "gmcNumber": "1234567", "recommendationType": "REVALIDATE",
+                              "recommendationStatus": "SUBMITTED_TO_GMC",
+                              "gmcSubmissionDate": {"$date": "2025-04-28T00:00:00Z"},
+                              "comments": ["test"], "admin": "aaa.bbb@ccc.com",
+                              "_class": "uk.nhs.hee.tis.revalidation.entity.Recommendation"},
+            "ns": {"db": "revalidation", "coll": "recommendation"},
+            "operationType": "update",
+            "updateDescription": {"removedFields": [], "truncatedArrays": [],
+                                  "updatedFields": {"recommendationStatus": "SUBMITTED_TO_GMC"}}}
+          """;
 
   @BeforeEach
   void setup() {
@@ -94,28 +93,38 @@ class CdcDateDeserializerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {CDC_DOC_JSON, CDC_DOCDB_JSON_GMC_NUMBER})
-  void shouldDeserializeGmcReferenceNumber(String jsonStr) throws JsonProcessingException {
-    CdcDocumentDto<DoctorsForDB> document =
-        mapper.readValue(jsonStr,
-            new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
-            }
-        );
-
-    assertThat(document.getFullDocument().getGmcReferenceNumber(), is(gmcId));
-  }
-
-  @ParameterizedTest
   @ValueSource(strings = {CDC_DOC_JSON, CDC_DOCDB_EVENT_JSON})
-  void shouldDeserializeDateStr(String jsonStr) throws JsonProcessingException {
+  void shouldDeserializeDocDbJsonStr(String jsonStr) throws JsonProcessingException {
     CdcDocumentDto<DoctorsForDB> document =
         mapper.readValue(jsonStr, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
             }
         );
 
-    LocalDate dateAdded = document.getFullDocument().getDateAdded();
+    DoctorsForDB doctorsForDb = document.getFullDocument();
+    assertThat(doctorsForDb.getUnderNotice(), is(UnderNotice.NO));
+    assertThat(doctorsForDb.getExistsInGmc(), is(false));
+
+    LocalDate dateAdded = doctorsForDb.getDateAdded();
     assertThat(dateAdded.getDayOfMonth(), is(7));
     assertThat(dateAdded.getMonthValue(), is(10));
     assertThat(dateAdded.getYear(), is(2015));
+  }
+
+  @Test
+  void shouldDeserializeRecommendationJsonStr() throws JsonProcessingException {
+    CdcDocumentDto<Recommendation> document =
+        mapper.readValue(CDC_RECOMMENDATION_EVENT_JSON,
+            new TypeReference<CdcDocumentDto<Recommendation>>() {
+            }
+        );
+
+    Recommendation recommendation = document.getFullDocument();
+    assertThat(recommendation.getGmcNumber(), is("1234567"));
+    assertThat(recommendation.getRecommendationStatus(), is(RecommendationStatus.SUBMITTED_TO_GMC));
+
+    LocalDate dateAdded = recommendation.getGmcSubmissionDate();
+    assertThat(dateAdded.getDayOfMonth(), is(28));
+    assertThat(dateAdded.getMonthValue(), is(4));
+    assertThat(dateAdded.getYear(), is(2025));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 class CdcDateDeserializerTest {
 
   private ObjectMapper mapper;
-  private final static String CDC_DOC_JSON =
+  private static final String CDC_DOC_JSON =
       """
           {
             "_id":{"_data":"01625a0706000001c001000001c000020042"},
@@ -30,15 +30,20 @@ class CdcDateDeserializerTest {
             "ns":{"db":"revalidation","coll":"doctorsForDB"},
             "documentKey":{"_id":"1234567"},
             "fullDocument":{
-                              "_id":"1234567","doctorFirstName":"First","doctorLastName":"Last",
-                               "submissionDate":"2017-10-19 00:00:00","dateAdded":"2015-10-07 00:00:00",
-                               "underNotice":"NO","sanction":"No","doctorStatus":"COMPLETED",
-                               "lastUpdatedDate":"2022-04-15 00:00:00","designatedBodyCode":"1-AIIDWI",
-                               "existsInGmc":false,"_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}
+                              "_id":"1234567","doctorFirstName":"First",
+                              "doctorLastName":"Last",
+                              "submissionDate":"2017-10-19 00:00:00",
+                              "dateAdded":"2015-10-07 00:00:00",
+                              "underNotice":"NO","sanction":"No",
+                              "doctorStatus":"COMPLETED",
+                              "lastUpdatedDate":"2022-04-15 00:00:00",
+                              "designatedBodyCode":"1-AIIDWI",
+                              "existsInGmc":false,
+                              "_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}
           }
           """;
 
-  private final static String CDC_DOCDB_JSON_GMC_NUMBER =
+  private static final String CDC_DOCDB_JSON_GMC_NUMBER =
       """
           {
             "gmcReferenceNumber":{"_data":"01625a0706000001c001000001c000020042"},
@@ -47,15 +52,20 @@ class CdcDateDeserializerTest {
             "ns":{"db":"revalidation","coll":"doctorsForDB"},
             "documentKey":{"_id":"1234567"},
             "fullDocument":{
-                              "_id":"1234567","doctorFirstName":"First","doctorLastName":"Last",
-                              "submissionDate":"2017-10-19 00:00:00","dateAdded":"2015-10-07 00:00:00",
-                              "underNotice":"NO","sanction":"No","doctorStatus":"COMPLETED",
-                              "lastUpdatedDate":"2022-04-15 00:00:00","designatedBodyCode":"1-AIIDWI",
-                              "existsInGmc":false,"_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}}
+                              "_id":"1234567","doctorFirstName":"First",
+                              "doctorLastName":"Last",
+                              "submissionDate":"2017-10-19 00:00:00",
+                              "dateAdded":"2015-10-07 00:00:00",
+                              "underNotice":"NO","sanction":"No",
+                              "doctorStatus":"COMPLETED",
+                              "lastUpdatedDate":"2022-04-15 00:00:00",
+                              "designatedBodyCode":"1-AIIDWI",
+                              "existsInGmc":false,
+                              "_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}}
           """;
 
 
-  private final static String CDC_DOCDB_EVENT_JSON =
+  private static final String CDC_DOCDB_EVENT_JSON =
       """
           {
             "_id": {"_data": "016819321a00000001010000000000020042"},
@@ -72,30 +82,11 @@ class CdcDateDeserializerTest {
                               "_class": "uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"},
             "ns": {"db": "revalidation", "coll": "doctorsForDB"},
             "operationType": "update",
-            "updateDescription": {"removedFields": [], "truncatedArrays": [], "updatedFields": {"underNotice": "YES"}}
+            "updateDescription": {"removedFields": [], "truncatedArrays": [],
+                                  "updatedFields": {"underNotice": "YES"}}
           }
           """;
 
-  private final static String CDC_DOCDB_EVENT_JSON_DATE_INVALID =
-      """
-          {
-            "_id": {"_data": "016819321a00000001010000000000020042"},
-            "clusterTime": {"$timestamp": {"t": 1746481690, "i": 1}},
-            "documentKey": {"_id": "1234567"},
-            "fullDocument": {
-                              "_id": "1234567", "doctorFirstName": "AAA", "doctorLastName": "BBB",
-                              "submissionDate": {"$date": "05/08/2024"},
-                              "dateAdded": {"$date": "07/10/2015"}, "underNotice": "YES",
-                              "sanction": "No", "doctorStatus": "DRAFT",
-                              "lastUpdatedDate": {"$date": "2025-04-29T00:00:00Z"},
-                              "gmcLastUpdatedDateTime": {"$date": "2025-04-29T00:00:54.956Z"},
-                              "designatedBodyCode": "1-1RSSQ05", "existsInGmc": true,
-                              "_class": "uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"},
-            "ns": {"db": "revalidation", "coll": "doctorsForDB"},
-            "operationType": "update",
-            "updateDescription": {"removedFields": [], "truncatedArrays": [], "updatedFields": {"underNotice": "YES"}}
-          }
-          """;
   private String gmcId = "1234567";
 
   @BeforeEach

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcDateDeserializerTest.java
@@ -2,41 +2,104 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.message.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.RevalidationIntegrationApplication;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
 
+import java.time.LocalDate;
+
 @ExtendWith(MockitoExtension.class)
 class CdcDateDeserializerTest {
 
   private ObjectMapper mapper;
-  private String cdcDocumentJson = "{\"_id\":{\"_data\":\"01625a0706000001c001000001c000020042\"},"
-      + "\"operationType\":\"replace\",\"clusterTime\":\"Timestamp(1650067206, 448)\",\"ns\""
-      + ":{\"db\":\"revalidation\",\"coll\":\"doctorsForDB\"},\"documentKey\""
-      + ":{\"_id\":\"1234567\"},\"fullDocument\":{\"_id\":\"1234567\",\"doctorFirstName\":\""
-      + "First\",\"doctorLastName\":\"Last\",\"submissionDate\":\"2017-10-19 00:00:00\""
-      + ",\"dateAdded\":\"2015-10-07 00:00:00\",\"underNotice\":\"NO\",\"sanction\":"
-      + "\"No\",\"doctorStatus\":\"COMPLETED\",\"lastUpdatedDate\":\"2022-04-15 00:00:00\","
-      + "\"designatedBodyCode\":\"1-AIIDWI\",\"existsInGmc\":false,\"_class\":"
-      + "\"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB\"}}";
-  private String cdcDocumentJsonGmcReferencNumber =
-      "{\"gmcReferenceNumber\":{\"_data\":\"01625a0706000001c001000001c000020042\"},"
-          + "\"operationType\":\"replace\",\"clusterTime\":\"Timestamp(1650067206, 448)\",\"ns\""
-          + ":{\"db\":\"revalidation\",\"coll\":\"doctorsForDB\"},\"documentKey\""
-          + ":{\"_id\":\"1234567\"},\"fullDocument\":{\"_id\":\"1234567\",\"doctorFirstName\":"
-          + "\"First\",\"doctorLastName\":\"Last\",\"submissionDate\":\"2017-10-19 00:00:00\""
-          + ",\"dateAdded\":\"2015-10-07 00:00:00\",\"underNotice\":\"NO\",\"sanction\":"
-          + "\"No\",\"doctorStatus\":\"COMPLETED\",\"lastUpdatedDate\":\"2022-04-15 00:00:00\","
-          + "\"designatedBodyCode\":\"1-AIIDWI\",\"existsInGmc\":false,\"_class\":"
-          + "\"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB\"}}";
+  private final static String CDC_DOC_JSON =
+      """
+          {
+            "_id":{"_data":"01625a0706000001c001000001c000020042"},
+            "operationType":"replace",
+            "clusterTime":"Timestamp(1650067206, 448)",
+            "ns":{"db":"revalidation","coll":"doctorsForDB"},
+            "documentKey":{"_id":"1234567"},
+            "fullDocument":{
+                              "_id":"1234567","doctorFirstName":"First","doctorLastName":"Last",
+                               "submissionDate":"2017-10-19 00:00:00","dateAdded":"2015-10-07 00:00:00",
+                               "underNotice":"NO","sanction":"No","doctorStatus":"COMPLETED",
+                               "lastUpdatedDate":"2022-04-15 00:00:00","designatedBodyCode":"1-AIIDWI",
+                               "existsInGmc":false,"_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}
+          }
+          """;
+
+  private final static String CDC_DOCDB_JSON_GMC_NUMBER =
+      """
+          {
+            "gmcReferenceNumber":{"_data":"01625a0706000001c001000001c000020042"},
+            "operationType":"replace",
+            "clusterTime":"Timestamp(1650067206, 448)",
+            "ns":{"db":"revalidation","coll":"doctorsForDB"},
+            "documentKey":{"_id":"1234567"},
+            "fullDocument":{
+                              "_id":"1234567","doctorFirstName":"First","doctorLastName":"Last",
+                              "submissionDate":"2017-10-19 00:00:00","dateAdded":"2015-10-07 00:00:00",
+                              "underNotice":"NO","sanction":"No","doctorStatus":"COMPLETED",
+                              "lastUpdatedDate":"2022-04-15 00:00:00","designatedBodyCode":"1-AIIDWI",
+                              "existsInGmc":false,"_class":"uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"}}
+          """;
+
+
+  private final static String CDC_DOCDB_EVENT_JSON =
+      """
+          {
+            "_id": {"_data": "016819321a00000001010000000000020042"},
+            "clusterTime": {"$timestamp": {"t": 1746481690, "i": 1}},
+            "documentKey": {"_id": "1234567"},
+            "fullDocument": {
+                              "_id": "1234567", "doctorFirstName": "AAA", "doctorLastName": "BBB",
+                              "submissionDate": {"$date": "2024-08-05T00:00:00Z"},
+                              "dateAdded": {"$date": "2015-10-07T00:00:00Z"}, "underNotice": "YES",
+                              "sanction": "No", "doctorStatus": "DRAFT",
+                              "lastUpdatedDate": {"$date": "2025-04-29T00:00:00Z"},
+                              "gmcLastUpdatedDateTime": {"$date": "2025-04-29T00:00:54.956Z"},
+                              "designatedBodyCode": "1-1RSSQ05", "existsInGmc": true,
+                              "_class": "uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"},
+            "ns": {"db": "revalidation", "coll": "doctorsForDB"},
+            "operationType": "update",
+            "updateDescription": {"removedFields": [], "truncatedArrays": [], "updatedFields": {"underNotice": "YES"}}
+          }
+          """;
+
+  private final static String CDC_DOCDB_EVENT_JSON_DATE_INVALID =
+      """
+          {
+            "_id": {"_data": "016819321a00000001010000000000020042"},
+            "clusterTime": {"$timestamp": {"t": 1746481690, "i": 1}},
+            "documentKey": {"_id": "1234567"},
+            "fullDocument": {
+                              "_id": "1234567", "doctorFirstName": "AAA", "doctorLastName": "BBB",
+                              "submissionDate": {"$date": "05/08/2024"},
+                              "dateAdded": {"$date": "07/10/2015"}, "underNotice": "YES",
+                              "sanction": "No", "doctorStatus": "DRAFT",
+                              "lastUpdatedDate": {"$date": "2025-04-29T00:00:00Z"},
+                              "gmcLastUpdatedDateTime": {"$date": "2025-04-29T00:00:54.956Z"},
+                              "designatedBodyCode": "1-1RSSQ05", "existsInGmc": true,
+                              "_class": "uk.nhs.hee.tis.revalidation.entity.DoctorsForDB"},
+            "ns": {"db": "revalidation", "coll": "doctorsForDB"},
+            "operationType": "update",
+            "updateDescription": {"removedFields": [], "truncatedArrays": [], "updatedFields": {"underNotice": "YES"}}
+          }
+          """;
   private String gmcId = "1234567";
 
   @BeforeEach
@@ -44,47 +107,39 @@ class CdcDateDeserializerTest {
     this.mapper = new RevalidationIntegrationApplication().mapper();
   }
 
-  @Test
-  void shouldDeserializeGmcReferenceNumber() throws JsonProcessingException {
+  @ParameterizedTest
+  @ValueSource(strings = {CDC_DOC_JSON, CDC_DOCDB_JSON_GMC_NUMBER})
+  void shouldDeserializeGmcReferenceNumber(String jsonStr) throws JsonProcessingException {
     CdcDocumentDto<DoctorsForDB> document =
-        mapper.readValue(cdcDocumentJson, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {}
+        mapper.readValue(jsonStr,
+            new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
+            }
         );
 
     assertThat(document.getFullDocument().getGmcReferenceNumber(), is(gmcId));
   }
 
-  @Test
-  void shouldDeserializeGmcReferenceNumberFromAlias() throws JsonProcessingException {
+  @ParameterizedTest
+  @ValueSource(strings = {CDC_DOC_JSON, CDC_DOCDB_EVENT_JSON})
+  void shouldDeserializeDateStr(String jsonStr) throws JsonProcessingException {
     CdcDocumentDto<DoctorsForDB> document =
-        mapper.readValue(cdcDocumentJsonGmcReferencNumber,
-            new TypeReference<CdcDocumentDto<DoctorsForDB>>() {}
+        mapper.readValue(jsonStr, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
+            }
         );
 
-    assertThat(document.getFullDocument().getGmcReferenceNumber(), is(gmcId));
+    LocalDate dateAdded = document.getFullDocument().getDateAdded();
+    assertThat(dateAdded.getDayOfMonth(), is(7));
+    assertThat(dateAdded.getMonthValue(), is(10));
+    assertThat(dateAdded.getYear(), is(2015));
   }
 
   @Test
-  void shouldDeserializeMongoDateString() throws JsonProcessingException {
-    CdcDocumentDto<DoctorsForDB> document =
-        mapper.readValue(cdcDocumentJson, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {}
-        );
+  void shouldThrowErrorWhenDateInvalid() {
+    JsonMappingException thrown = assertThrows(JsonMappingException.class, () ->
+        mapper.readValue(CDC_DOCDB_EVENT_JSON_DATE_INVALID, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
+            }
+        ), "Expected JsonMappingException to throw, but it didn't");
 
-    assertThat(document.getFullDocument().getDateAdded().getDayOfMonth(), is(7));
-    assertThat(document.getFullDocument().getDateAdded().getMonthValue(), is(10));
-    assertThat(document.getFullDocument().getDateAdded().getYear(), is(2015));
+    assertTrue(thrown.getMessage().contains("Not supported date format:"));
   }
-
-  @Test
-  void shouldDeserializeLocalDateString() throws JsonProcessingException {
-    CdcDocumentDto<DoctorsForDB> document =
-        mapper.readValue(cdcDocumentJson, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {}
-        );
-    var newJson = mapper.writeValueAsString(document.getFullDocument());
-    var doctorsForDb = mapper.readValue(newJson, DoctorsForDB.class);
-
-    assertThat(doctorsForDb.getDateAdded().getDayOfMonth(), is(7));
-    assertThat(doctorsForDb.getDateAdded().getMonthValue(), is(10));
-    assertThat(doctorsForDb.getDateAdded().getYear(), is(2015));
-  }
-
 }


### PR DESCRIPTION
When testing DocumentDB trigger, I found in the cdc event messages, the date format is changed to an object type as "{$date": "2025-04-29T00:00:00Z"}, so made some changes on the deserializer. 
Beside, I tested by updating data in the docDB collection directly and noticed UPDATE operation type is not handled, so added it in.

TIS21-6275