### PR TITLE
feat: propagate hidden discrepancies to open/elasticsearch

### DIFF
--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -204,6 +204,10 @@
           "valueFrom": "/tis/revalidation/documentdb-cdc/prod/queue-url/connectionlogs"
         },
         {
+          "name": "SQS_CDC_HIDDEN_DISCREPANCY_QUEUE",
+          "valueFrom": "/tis/revalidation/documentdb-cdc/prod/queue-url/hiddendiscrepancy"
+        },
+        {
           "name": "ESSYNC_GMC_DATA_QUEUE",
           "valueFrom": "/tis/revalidation/prod/rabbit/queue/revalidationsummary/essync/integration"
         },
@@ -214,6 +218,14 @@
         {
           "name": "CONNECTION_LOG_ESSYNCSTART_ROUTING_KEY",
           "valueFrom": "/tis/revalidation/prod/rabbit/routingkey/connectionlog/essyncstart"
+        },
+        {
+          "name": "HIDDEN_DISCREPANCY_ESSYNCDATA_QUEUE",
+          "valueFrom": "/tis/revalidation/prod/rabbit/queue/hiddendiscrepancy/essyncdata/integration"
+        },
+        {
+          "name": "HIDDEN_DISCREPANCY_ESSYNCSTART_ROUTING_KEY",
+          "valueFrom": "/tis/revalidation/prod/rabbit/routingkey/hiddendiscrepancy/essyncstart"
         }
       ]
     }

--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -196,6 +196,10 @@
           "valueFrom": "/tis/revalidation/documentdb-cdc/preprod/queue-url/doctorsfordb"
         },
         {
+          "name": "SQS_CDC_HIDDEN_DISCREPANCY_QUEUE",
+          "valueFrom": "/tis/revalidation/documentdb-cdc/preprod/queue-url/hiddendiscrepancy"
+        },
+        {
           "name": "SQS_CDC_RECOMMENDATION_QUEUE",
           "valueFrom": "/tis/revalidation/documentdb-cdc/preprod/queue-url/recommendation"
         },
@@ -214,6 +218,14 @@
         {
           "name": "CONNECTION_LOG_ESSYNCSTART_ROUTING_KEY",
           "valueFrom": "/tis/revalidation/preprod/rabbit/routingkey/connectionlog/essyncstart"
+        },
+        {
+          "name": "HIDDEN_DISCREPANCY_ESSYNCDATA_QUEUE",
+          "valueFrom": "/tis/revalidation/preprod/rabbit/queue/hiddendiscrepancy/essyncdata/integration"
+        },
+        {
+          "name": "HIDDEN_DISCREPANCY_ESSYNCSTART_ROUTING_KEY",
+          "valueFrom": "/tis/revalidation/preprod/rabbit/routingkey/hiddendiscrepancy/essyncstart"
         }
       ]
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.13.0"
+version = "0.14.0"
 sourceCompatibility = "17"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcHiddenDiscrepancyMessageHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcHiddenDiscrepancyMessageHandler.java
@@ -26,7 +26,7 @@ import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcHiddenDiscrepancyS
 import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 
 /**
- * A component class to handle cdc connection log messages.
+ * A component class to handle cdc hidden discrepancy messages.
  */
 @Component
 public class CdcHiddenDiscrepancyMessageHandler extends CdcMessageHandler<HiddenDiscrepancy> {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcHiddenDiscrepancyMessageHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcHiddenDiscrepancyMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,27 +19,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.integration.cdc.service;
+package uk.nhs.hee.tis.revalidation.integration.cdc.message.handler;
 
-import lombok.extern.slf4j.Slf4j;
-import uk.nhs.hee.tis.revalidation.integration.sync.repository.MasterDoctorElasticSearchRepository;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcHiddenDiscrepancyService;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 
-@Slf4j
-public abstract class CdcService<T> {
+/**
+ * A component class to handle cdc connection log messages.
+ */
+@Component
+public class CdcHiddenDiscrepancyMessageHandler extends CdcMessageHandler<HiddenDiscrepancy> {
 
-  private MasterDoctorElasticSearchRepository repository;
-
-  protected CdcService(
-      MasterDoctorElasticSearchRepository repository
-  ) {
-    this.repository = repository;
+  public CdcHiddenDiscrepancyMessageHandler(
+      CdcHiddenDiscrepancyService cdcHiddenDiscrepancyService) {
+    super(cdcHiddenDiscrepancyService);
   }
-
-  protected MasterDoctorElasticSearchRepository getRepository() {
-    return this.repository;
-  }
-
-  public abstract void upsertEntity(T entity);
-
-  public abstract void deleteEntity(T entity);
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcMessageHandler.java
@@ -47,6 +47,9 @@ public abstract class CdcMessageHandler<T> implements MessageHandler<CdcDocument
       case INSERT, REPLACE, UPDATE:
         cdcService.upsertEntity(message.getFullDocument());
         break;
+      case DELETE:
+        cdcService.deleteEntity(message.getFullDocument());
+        break;
       default:
         throw new OperationNotSupportedException("CDC operation not supported: " + operation);
     }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListener.java
@@ -31,14 +31,15 @@ import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcConnectionMessageHandler;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcDoctorMessageHandler;
+import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcHiddenDiscrepancyMessageHandler;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcRecommendationMessageHandler;
 import uk.nhs.hee.tis.revalidation.integration.entity.ConnectionLog;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.entity.Recommendation;
 
 /**
  * A class to listen all the log messages.
- *
  */
 @Slf4j
 @Component
@@ -47,6 +48,7 @@ public class CdcSqsMessageListener {
   private final CdcRecommendationMessageHandler cdcRecommendationMessageHandler;
   private final CdcDoctorMessageHandler cdcDoctorMessageHandler;
   private final CdcConnectionMessageHandler cdcConnectionMessageHandler;
+  private final CdcHiddenDiscrepancyMessageHandler cdcHiddenDiscrepancyMessageHandler;
   private final ObjectMapper mapper;
 
   /**
@@ -62,10 +64,12 @@ public class CdcSqsMessageListener {
       CdcRecommendationMessageHandler cdcRecommendationMessageHandler,
       CdcDoctorMessageHandler cdcDoctorMessageHandler,
       CdcConnectionMessageHandler cdcConnectionMessageHandler,
+      CdcHiddenDiscrepancyMessageHandler cdcHiddenDiscrepancyMessageHandler,
       ObjectMapper mapper) {
     this.cdcRecommendationMessageHandler = cdcRecommendationMessageHandler;
     this.cdcDoctorMessageHandler = cdcDoctorMessageHandler;
     this.cdcConnectionMessageHandler = cdcConnectionMessageHandler;
+    this.cdcHiddenDiscrepancyMessageHandler = cdcHiddenDiscrepancyMessageHandler;
     this.mapper = mapper;
   }
 
@@ -78,7 +82,8 @@ public class CdcSqsMessageListener {
   public void getRecommendationMessage(String message) throws IOException {
     try {
       CdcDocumentDto<Recommendation> cdcDocument =
-          mapper.readValue(message, new TypeReference<>() {});
+          mapper.readValue(message, new TypeReference<>() {
+          });
       cdcRecommendationMessageHandler.handleMessage(cdcDocument);
     } catch (OperationNotSupportedException e) {
       log.error(e.getMessage(), e);
@@ -94,7 +99,8 @@ public class CdcSqsMessageListener {
   public void getDoctorMessage(String message) throws IOException {
     try {
       CdcDocumentDto<DoctorsForDB> cdcDocument =
-          mapper.readValue(message, new TypeReference<>() {});
+          mapper.readValue(message, new TypeReference<>() {
+          });
       cdcDoctorMessageHandler.handleMessage(cdcDocument);
     } catch (OperationNotSupportedException e) {
       log.error(e.getMessage(), e);
@@ -110,8 +116,26 @@ public class CdcSqsMessageListener {
   public void getConnectionMessage(String message) throws IOException {
     try {
       CdcDocumentDto<ConnectionLog> cdcDocument =
-          mapper.readValue(message, new TypeReference<>() {});
+          mapper.readValue(message, new TypeReference<>() {
+          });
       cdcConnectionMessageHandler.handleMessage(cdcDocument);
+    } catch (OperationNotSupportedException e) {
+      log.error(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Get hidden discrepancy cdc message which is a json string.
+   *
+   * @param message containing change data for a hiddenDiscrepancy
+   */
+  @SqsListener("${cloud.aws.end-point.cdc.hiddendiscrepancy}")
+  public void getHiddenDiscrepancyMessage(String message) throws IOException {
+    try {
+      CdcDocumentDto<HiddenDiscrepancy> cdcDocument =
+          mapper.readValue(message, new TypeReference<>() {
+          });
+      cdcHiddenDiscrepancyMessageHandler.handleMessage(cdcDocument);
     } catch (OperationNotSupportedException e) {
       log.error(e.getMessage(), e);
     }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcConnectionService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcConnectionService.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
 import uk.nhs.hee.tis.revalidation.integration.entity.ConnectionLog;
@@ -103,5 +104,10 @@ public class CdcConnectionService extends CdcService<ConnectionLog> {
       log.error("CDC error adding connection: {}, exception: {}", entity, e.getMessage(), e);
       throw e;
     }
+  }
+
+  @Override
+  public void deleteEntity(ConnectionLog entity) {
+    throw new NotImplementedException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcDoctorService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcDoctorService.java
@@ -25,6 +25,7 @@ import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
@@ -46,9 +47,9 @@ public class CdcDoctorService extends CdcService<DoctorsForDB> {
   /**
    * Create a service.
    *
-   * @param repository The ElasticSearch repository with the index managed by the service
+   * @param repository        The ElasticSearch repository with the index managed by the service
    * @param esDocUpdateHelper the helper to update ES docs
-   * @param mapper a mapper for converting to/from the persisted composite view
+   * @param mapper            a mapper for converting to/from the persisted composite view
    */
   public CdcDoctorService(MasterDoctorElasticSearchRepository repository,
       EsDocUpdateHelper esDocUpdateHelper,
@@ -84,9 +85,14 @@ public class CdcDoctorService extends CdcService<DoctorsForDB> {
       }
     } catch (Exception e) {
       log.error(String.format("Failed to insert new record for gmcId: %s, error: %s",
-          entity.getGmcReferenceNumber(), e.getMessage()),
+              entity.getGmcReferenceNumber(), e.getMessage()),
           e);
       throw e;
     }
+  }
+
+  @Override
+  public void deleteEntity(DoctorsForDB entity) {
+    throw new NotImplementedException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
@@ -1,0 +1,141 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.cdc.service;
+
+import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.MASTER_DOCTOR_INDEX;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
+import uk.nhs.hee.tis.revalidation.integration.sync.repository.MasterDoctorElasticSearchRepository;
+import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
+
+/**
+ * A service class that updates connection log fields.
+ */
+@Slf4j
+@Service
+public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
+
+  private final EsDocUpdateHelper esUpdateHelper;
+
+  /**
+   * Service responsible for updating the ConnectionLog composite fields used for searching.
+   */
+  public CdcHiddenDiscrepancyService(
+      MasterDoctorElasticSearchRepository repository,
+      EsDocUpdateHelper esUpdateHelper
+  ) {
+    super(repository);
+    this.esUpdateHelper = esUpdateHelper;
+  }
+
+  /**
+   * Add new connection to index (this is an aggregation, updating an existing record).
+   *
+   * @param entity connectionlog to add to index
+   */
+  @Override
+  public void upsertEntity(HiddenDiscrepancy entity) {
+    String gmcId = entity.getGmcReferenceNumber();
+    final var repository = getRepository();
+
+    try {
+      List<MasterDoctorView> masterDoctorViewList = repository.findByGmcReferenceNumber(gmcId);
+      if (!masterDoctorViewList.isEmpty()) {
+        MasterDoctorView masterDoctorView = handleDuplicateRecords(masterDoctorViewList);
+
+        List<HiddenDiscrepancy> hiddenDiscrepancies = new ArrayList<>();
+
+        if (masterDoctorView.getHiddenDiscrepancies() != null) {
+          hiddenDiscrepancies.addAll(masterDoctorView.getHiddenDiscrepancies());
+        }
+
+        boolean alreadyHidden = hiddenDiscrepancies.stream().anyMatch(h ->
+            h.getHiddenForDesignatedBodyCode().equals(entity.getHiddenForDesignatedBodyCode()));
+
+        if (alreadyHidden) {
+          log.info(
+              "gmcReferenceNumber: {} already has a hidden discrepancy for designated body: {}",
+              entity.getGmcReferenceNumber(), entity.getHiddenForDesignatedBodyCode());
+          return;
+        }
+
+        hiddenDiscrepancies.add(entity);
+
+        // Partial updates on fields related to connection logs
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("hiddenDiscrepancies", hiddenDiscrepancies);
+        esUpdateHelper.partialUpdate(MASTER_DOCTOR_INDEX,
+            masterDoctorView.getId(), doc, MasterDoctorView.class);
+      }
+    } catch (Exception e) {
+      log.error("CDC error adding hidden discrepancy: {}, exception: {}", entity, e.getMessage(),
+          e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void deleteEntity(HiddenDiscrepancy entity) {
+    String gmcId = entity.getGmcReferenceNumber();
+    final var repository = getRepository();
+
+    try {
+      List<MasterDoctorView> masterDoctorViewList = repository.findByGmcReferenceNumber(gmcId);
+      if (!masterDoctorViewList.isEmpty()) {
+        MasterDoctorView masterDoctorView = handleDuplicateRecords(masterDoctorViewList);
+
+        List<HiddenDiscrepancy> updatedList = new ArrayList<>();
+        if (masterDoctorView.getHiddenDiscrepancies() != null) {
+          updatedList = masterDoctorView.getHiddenDiscrepancies().stream()
+              .filter(h -> !h.getHiddenForDesignatedBodyCode()
+                  .equals(entity.getHiddenForDesignatedBodyCode())).toList();
+        }
+        // Partial updates on fields related to connection logs
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("hiddenDiscrepancies", updatedList);
+        esUpdateHelper.partialUpdate(MASTER_DOCTOR_INDEX,
+            masterDoctorView.getId(), doc, MasterDoctorView.class);
+      }
+
+    } catch (Exception e) {
+      log.error("CDC error removing hidden discrepancy: {}, exception: {}", entity, e.getMessage(),
+          e);
+      throw e;
+    }
+  }
+
+  private MasterDoctorView handleDuplicateRecords(List<MasterDoctorView> masterDoctorViewList) {
+    if (masterDoctorViewList.size() > 1) {
+      log.error("Multiple doctors assigned to the same GMC number: {}",
+          masterDoctorViewList.get(0).getGmcReferenceNumber());
+    }
+    return masterDoctorViewList.get(0);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
@@ -23,7 +23,6 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.service;
 
 import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.MASTER_DOCTOR_INDEX;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +61,7 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
    */
   @Override
   public void upsertEntity(HiddenDiscrepancy entity) {
-    String gmcId = entity.getGmcReferenceNumber();
+    String gmcId = entity.getGmcId();
     final var repository = getRepository();
 
     try {
@@ -82,7 +81,7 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
         if (alreadyHidden) {
           log.info(
               "gmcReferenceNumber: {} already has a hidden discrepancy for designated body: {}",
-              entity.getGmcReferenceNumber(), entity.getHiddenForDesignatedBodyCode());
+              entity.getGmcId(), entity.getHiddenForDesignatedBodyCode());
           return;
         }
 
@@ -103,7 +102,7 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
 
   @Override
   public void deleteEntity(HiddenDiscrepancy entity) {
-    String gmcId = entity.getGmcReferenceNumber();
+    String gmcId = entity.getGmcId();
     final var repository = getRepository();
 
     try {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
@@ -38,18 +38,13 @@ import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 @Slf4j
 @Service
 public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
-
-  private final EsDocUpdateHelper esUpdateHelper;
-
   /**
    * Service responsible for updating the hidden discrepancy nested fields used for searching.
    */
   public CdcHiddenDiscrepancyService(
-      MasterDoctorElasticSearchRepository repository,
-      EsDocUpdateHelper esUpdateHelper
+      MasterDoctorElasticSearchRepository repository
   ) {
     super(repository);
-    this.esUpdateHelper = esUpdateHelper;
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyService.java
@@ -21,12 +21,10 @@
 
 package uk.nhs.hee.tis.revalidation.integration.cdc.service;
 
-import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.MASTER_DOCTOR_INDEX;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
@@ -35,7 +33,7 @@ import uk.nhs.hee.tis.revalidation.integration.sync.repository.MasterDoctorElast
 import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
 
 /**
- * A service class that updates connection log fields.
+ * A service class that updates hidden discrepancy fields.
  */
 @Slf4j
 @Service
@@ -44,7 +42,7 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
   private final EsDocUpdateHelper esUpdateHelper;
 
   /**
-   * Service responsible for updating the ConnectionLog composite fields used for searching.
+   * Service responsible for updating the hidden discrepancy nested fields used for searching.
    */
   public CdcHiddenDiscrepancyService(
       MasterDoctorElasticSearchRepository repository,
@@ -55,9 +53,9 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
   }
 
   /**
-   * Add new connection to index (this is an aggregation, updating an existing record).
+   * Add new hidden discrepancy to index (this is an aggregation, updating an existing record).
    *
-   * @param entity connectionlog to add to index
+   * @param entity hidden discrepancy to add to index
    */
   @Override
   public void upsertEntity(HiddenDiscrepancy entity) {
@@ -86,12 +84,10 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
         }
 
         hiddenDiscrepancies.add(entity);
+        masterDoctorView = repository.findByGmcReferenceNumber(gmcId).get(0);
+        masterDoctorView.setHiddenDiscrepancies(hiddenDiscrepancies);
 
-        // Partial updates on fields related to connection logs
-        Map<String, Object> doc = new HashMap<>();
-        doc.put("hiddenDiscrepancies", hiddenDiscrepancies);
-        esUpdateHelper.partialUpdate(MASTER_DOCTOR_INDEX,
-            masterDoctorView.getId(), doc, MasterDoctorView.class);
+        repository.save(masterDoctorView);
       }
     } catch (Exception e) {
       log.error("CDC error adding hidden discrepancy: {}, exception: {}", entity, e.getMessage(),
@@ -116,11 +112,11 @@ public class CdcHiddenDiscrepancyService extends CdcService<HiddenDiscrepancy> {
               .filter(h -> !h.getHiddenForDesignatedBodyCode()
                   .equals(entity.getHiddenForDesignatedBodyCode())).toList();
         }
-        // Partial updates on fields related to connection logs
-        Map<String, Object> doc = new HashMap<>();
-        doc.put("hiddenDiscrepancies", updatedList);
-        esUpdateHelper.partialUpdate(MASTER_DOCTOR_INDEX,
-            masterDoctorView.getId(), doc, MasterDoctorView.class);
+
+        masterDoctorView = repository.findByGmcReferenceNumber(gmcId).get(0);
+        masterDoctorView.setHiddenDiscrepancies(updatedList);
+
+        repository.save(masterDoctorView);
       }
 
     } catch (Exception e) {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcRecommendationService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcRecommendationService.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
 import uk.nhs.hee.tis.revalidation.integration.entity.Recommendation;
@@ -81,5 +82,10 @@ public class CdcRecommendationService extends CdcService<Recommendation> {
           e);
       throw e;
     }
+  }
+
+  @Override
+  public void deleteEntity(Recommendation entity) {
+    throw new NotImplementedException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateService.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.revalidation.integration.cdc.service;
 
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.ConnectionInfoDto;
 import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapper;
@@ -147,5 +148,10 @@ public class CdcTraineeUpdateService extends CdcService<ConnectionInfoDto> {
 
       detachTisInfoIfGmcNumberNotMatch(receivedDto);
     }
+  }
+
+  @Override
+  public void deleteEntity(ConnectionInfoDto entity) {
+    throw new NotImplementedException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import uk.nhs.hee.tis.revalidation.integration.cdc.message.util.CdcLocalDateTimeDeserializer;
+
+/**
+ * A class that represents a hidden discrepancy.
+ *
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HiddenDiscrepancy {
+
+  @Id
+  private String id;
+  private String gmcReferenceNumber;
+  private String hiddenForDesignatedBodyCode;
+  @JsonDeserialize(using = CdcLocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime hiddenDateTime;
+  private String hiddenBy;
+  private String reason;
+}
+

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
@@ -46,7 +46,7 @@ public class HiddenDiscrepancy {
 
   @Id
   private String id;
-  private String gmcReferenceNumber;
+  private String gmcId;
   private String hiddenForDesignatedBodyCode;
   @JsonDeserialize(using = CdcLocalDateTimeDeserializer.class)
   @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
@@ -37,14 +37,13 @@ import uk.nhs.hee.tis.revalidation.integration.cdc.message.util.CdcLocalDateTime
 
 /**
  * A class that represents a hidden discrepancy.
- *
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class HiddenDiscrepancy{
+public class HiddenDiscrepancy {
 
   private String id;
   private String gmcId;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/entity/HiddenDiscrepancy.java
@@ -30,7 +30,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.util.CdcLocalDateTimeDeserializer;
 
 /**
@@ -42,16 +44,16 @@ import uk.nhs.hee.tis.revalidation.integration.cdc.message.util.CdcLocalDateTime
 @NoArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class HiddenDiscrepancy {
+public class HiddenDiscrepancy{
 
-  @Id
   private String id;
   private String gmcId;
   private String hiddenForDesignatedBodyCode;
-  @JsonDeserialize(using = CdcLocalDateTimeDeserializer.class)
-  @JsonSerialize(using = LocalDateTimeSerializer.class)
-  private LocalDateTime hiddenDateTime;
   private String hiddenBy;
   private String reason;
+  @JsonDeserialize(using = CdcLocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS")
+  private LocalDateTime hiddenDateTime;
 }
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/ConnectionLogMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/ConnectionLogMessageListener.java
@@ -41,7 +41,7 @@ public class ConnectionLogMessageListener {
   @Value("${app.rabbit.reval.exchange}")
   private String revalExchange;
 
-  @Value("${app.rabbit.reval.routingKey.hiddendiscrepancies.essyncstart}")
+  @Value("${app.rabbit.reval.routingKey.hiddendiscrepancy.essyncstart}")
   private String hiddenDiscrepanciesSyncRoutingKey;
 
   private final DoctorUpsertElasticSearchService doctorUpsertElasticSearchService;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/HiddenDiscrepancyMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/HiddenDiscrepancyMessageListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2025 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -24,56 +24,43 @@ package uk.nhs.hee.tis.revalidation.integration.sync.listener;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.nhs.hee.tis.revalidation.integration.router.dto.ConnectionLogDto;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.router.message.payload.IndexSyncMessage;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.DoctorUpsertElasticSearchService;
 
 /**
- * Listener for connection log messages from RabbitMQ to sync data into Elasticsearch.
+ * Listener for hidden discrepancy messages from RabbitMQ to sync data into Elasticsearch.
  */
 @Slf4j
 @Service
-public class ConnectionLogMessageListener {
-
-  @Value("${app.rabbit.reval.exchange}")
-  private String revalExchange;
-
-  @Value("${app.rabbit.reval.routingKey.hiddendiscrepancies.essyncstart}")
-  private String hiddenDiscrepanciesSyncRoutingKey;
+public class HiddenDiscrepancyMessageListener {
 
   private final DoctorUpsertElasticSearchService doctorUpsertElasticSearchService;
 
-  private final RabbitTemplate rabbitTemplate;
-
   /**
-   * Constructor for the ConnectionLogMessageListener.
+   * Constructor for the HiddenDiscrepancyMessageListener.
    *
    * @param doctorUpsertElasticSearchService the service to upsert doctors in Elasticsearch
    */
-  public ConnectionLogMessageListener(
-      DoctorUpsertElasticSearchService doctorUpsertElasticSearchService,
-      RabbitTemplate rabbitTemplate) {
+  public HiddenDiscrepancyMessageListener(
+      DoctorUpsertElasticSearchService doctorUpsertElasticSearchService) {
     this.doctorUpsertElasticSearchService = doctorUpsertElasticSearchService;
-    this.rabbitTemplate = rabbitTemplate;
   }
 
   /**
-   * Receives connection log messages from RabbitMQ and processes them for Elasticsearch sync.
+   * Receives hidden discrepancy messages from RabbitMQ and processes them for Elasticsearch sync.
    *
-   * @param message the index sync message containing connection log data
+   * @param message the index sync message containing hiddenDiscrepancy data
    */
-  @RabbitListener(queues = "${app.rabbit.reval.queue.connectionlog.essyncdata}")
-  public void receiveConnectionLogMessage(IndexSyncMessage<List<ConnectionLogDto>> message) {
+  @RabbitListener(queues = "${app.rabbit.reval.queue.hiddendiscrepancy.essyncdata}")
+  public void receiveConnectionLogMessage(
+      IndexSyncMessage<List<HiddenDiscrepancy>> message) {
     if (message.getSyncEnd() != null && message.getSyncEnd()) {
-      log.info("ConnectionLogs ES sync completed. Starting hidden discrepancies sync.");
-      String hiddenDiscrepancySyncStart = "hiddenDiscrepancySyncStart";
-      rabbitTemplate.convertAndSend(revalExchange, hiddenDiscrepanciesSyncRoutingKey,
-          hiddenDiscrepancySyncStart);
+      log.info("Hidden Discrepancies ES sync completed.");
     } else {
-      doctorUpsertElasticSearchService.populateMasterIndexByConnectionLogs(message.getPayload());
+      doctorUpsertElasticSearchService.populateMasterIndexByHiddenDiscrepancies(
+          message.getPayload());
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
@@ -167,7 +167,7 @@ public class DoctorUpsertElasticSearchService {
       List<HiddenDiscrepancy> hiddenDiscrepancies) {
     hiddenDiscrepancies.forEach(hiddenDiscrepancy -> {
       Map<String, Map<String, Object>> updates = new HashMap<>();
-      String gmcReferenceNumber = hiddenDiscrepancy.getGmcReferenceNumber();
+      String gmcReferenceNumber = hiddenDiscrepancy.getGmcId();
       var existing = repository.findByGmcReferenceNumber(gmcReferenceNumber);
       if (existing.size() > 1) {
         log.warn(
@@ -189,7 +189,7 @@ public class DoctorUpsertElasticSearchService {
         if (alreadyHidden) {
           log.info(
               "gmcReferenceNumber: {} already has a hidden discrepancy for designated body: {}",
-              hiddenDiscrepancy.getGmcReferenceNumber(),
+              hiddenDiscrepancy.getGmcId(),
               hiddenDiscrepancy.getHiddenForDesignatedBodyCode());
           return;
         } else {
@@ -208,7 +208,6 @@ public class DoctorUpsertElasticSearchService {
       }
     });
   }
-
 
   private List<MasterDoctorView> findMasterDoctorRecordByGmcNumberPersonId(
       MasterDoctorView dataToSave) {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
@@ -166,17 +166,16 @@ public class DoctorUpsertElasticSearchService {
   public void populateMasterIndexByHiddenDiscrepancies(
       List<HiddenDiscrepancy> hiddenDiscrepancies) {
     hiddenDiscrepancies.forEach(hiddenDiscrepancy -> {
-      Map<String, Map<String, Object>> updates = new HashMap<>();
-      String gmcReferenceNumber = hiddenDiscrepancy.getGmcId();
-      var existing = repository.findByGmcReferenceNumber(gmcReferenceNumber);
+      List<HiddenDiscrepancy> hiddenDiscrepancyList = new ArrayList<>();
+      String gmcId = hiddenDiscrepancy.getGmcId();
+      var existing = repository.findByGmcReferenceNumber(gmcId);
       if (existing.size() > 1) {
         log.warn(
             "Multiple doctors found for gmcID: {} while syncing ES hidden discrepancy records,"
                 + " no hidden discrepancy records will be saved.",
-            gmcReferenceNumber);
+            gmcId);
       } else if (existing.size() == 1) {
         var masterDoctorView = existing.get(0);
-        List<HiddenDiscrepancy> hiddenDiscrepancyList = new ArrayList<>();
 
         if (masterDoctorView.getHiddenDiscrepancies() != null) {
           hiddenDiscrepancyList.addAll(masterDoctorView.getHiddenDiscrepancies());
@@ -196,15 +195,8 @@ public class DoctorUpsertElasticSearchService {
           hiddenDiscrepancyList.add(hiddenDiscrepancy);
         }
 
-        Map<String, Object> doc = new HashMap<>();
-        doc.put("hiddenDiscrepancies", hiddenDiscrepancyList);
-
-        updates.put(existing.get(0).getId(), doc);
-      }
-
-      if (!updates.isEmpty()) {
-        log.info("Updating {} master doctor records with hidden discrepancy data", updates.size());
-        esDocUpdateHelper.bulkPartialUpdate(MASTER_DOCTOR_INDEX, updates);
+        masterDoctorView.setHiddenDiscrepancies(hiddenDiscrepancyList);
+        repository.save(masterDoctorView);
       }
     });
   }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchService.java
@@ -39,6 +39,7 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.router.dto.ConnectionLogDto;
 import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapper;
 import uk.nhs.hee.tis.revalidation.integration.sync.helper.ElasticsearchIndexHelper;
@@ -132,8 +133,8 @@ public class DoctorUpsertElasticSearchService {
   }
 
   /**
-   * Populate the masterdoctorindex in bulk by updating multiple MasterDoctorViews from
-   * connection log data.
+   * Populate the masterdoctorindex in bulk by updating multiple MasterDoctorViews from connection
+   * log data.
    *
    * @param connectionDtos ConnectionLogDtos to update
    */
@@ -155,6 +156,59 @@ public class DoctorUpsertElasticSearchService {
       esDocUpdateHelper.bulkPartialUpdate(MASTER_DOCTOR_INDEX, updates);
     }
   }
+
+  /**
+   * Populate the masterdoctorindex in bulk by updating multiple MasterDoctorViews from hidden
+   * discrepancy data.
+   *
+   * @param hiddenDiscrepancies Hidden Discrepancies to update
+   */
+  public void populateMasterIndexByHiddenDiscrepancies(
+      List<HiddenDiscrepancy> hiddenDiscrepancies) {
+    hiddenDiscrepancies.forEach(hiddenDiscrepancy -> {
+      Map<String, Map<String, Object>> updates = new HashMap<>();
+      String gmcReferenceNumber = hiddenDiscrepancy.getGmcReferenceNumber();
+      var existing = repository.findByGmcReferenceNumber(gmcReferenceNumber);
+      if (existing.size() > 1) {
+        log.warn(
+            "Multiple doctors found for gmcID: {} while syncing ES hidden discrepancy records,"
+                + " no hidden discrepancy records will be saved.",
+            gmcReferenceNumber);
+      } else if (existing.size() == 1) {
+        var masterDoctorView = existing.get(0);
+        List<HiddenDiscrepancy> hiddenDiscrepancyList = new ArrayList<>();
+
+        if (masterDoctorView.getHiddenDiscrepancies() != null) {
+          hiddenDiscrepancyList.addAll(masterDoctorView.getHiddenDiscrepancies());
+        }
+
+        boolean alreadyHidden = hiddenDiscrepancyList.stream().anyMatch(h ->
+            h.getHiddenForDesignatedBodyCode()
+                .equals(hiddenDiscrepancy.getHiddenForDesignatedBodyCode()));
+
+        if (alreadyHidden) {
+          log.info(
+              "gmcReferenceNumber: {} already has a hidden discrepancy for designated body: {}",
+              hiddenDiscrepancy.getGmcReferenceNumber(),
+              hiddenDiscrepancy.getHiddenForDesignatedBodyCode());
+          return;
+        } else {
+          hiddenDiscrepancyList.add(hiddenDiscrepancy);
+        }
+
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("hiddenDiscrepancies", hiddenDiscrepancyList);
+
+        updates.put(existing.get(0).getId(), doc);
+      }
+
+      if (!updates.isEmpty()) {
+        log.info("Updating {} master doctor records with hidden discrepancy data", updates.size());
+        esDocUpdateHelper.bulkPartialUpdate(MASTER_DOCTOR_INDEX, updates);
+      }
+    });
+  }
+
 
   private List<MasterDoctorView> findMasterDoctorRecordByGmcNumberPersonId(
       MasterDoctorView dataToSave) {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/sync/view/MasterDoctorView.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -40,6 +41,7 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
 import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
 
@@ -107,4 +109,6 @@ public class MasterDoctorView {
   @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS")
   private LocalDateTime lastConnectionDateTime;
+  @Field(type = FieldType.Nested)
+  private List<HiddenDiscrepancy> hiddenDiscrepancies;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,12 +80,14 @@ app:
         connection.syncdata: ${REVAL_RABBIT_SYNC_DATA_QUEUE:reval.queue.connection.syncdata}
         revalidationsummary.essync.integration: ${ESSYNC_GMC_DATA_QUEUE:reval.queue.revalidationsummary.essync.integration}
         connectionlog.essyncdata: ${CONNECTION_LOG_ESSYNCDATA_QUEUE:reval.queue.connectionlog.essyncdata.integration}
+        hiddendiscrepancy.essyncdata: ${HIDDEN_DISCREPANCY_ESSYNCDATA_QUEUE:reval.queue.hiddendiscrepancy.essyncdata.integration}
       routingKey:
         connection.update: ${REVAL_RABBIT_ROUTING_KEY:reval.connection.update}
         connection.syncstart: ${REVAL_RABBIT_SYNCSTART_ROUTING_KEY:reval.connection.syncstart}
         recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNCSTART_ROUTING_KEY:reval.recommendation.syncstart}
         connection.syncdata: ${REVAL_RABBIT_SYNCDATA_ROUTING_KEY:reval.connection.syncdata}
         connectionlog.essyncstart: ${CONNECTION_LOG_ESSYNCSTART_ROUTING_KEY:reval.routingkey.connectionlog.essyncstart}
+        hiddendiscrepancy.essyncstart: ${HIDDEN_DISCREPANCY_ESSYNCSTART_ROUTING_KEY:reval.routingkey.hiddendiscrepancy.essyncstart}
 
 logging:
   level:
@@ -103,4 +105,5 @@ cloud:
       cdc.doctor: ${SQS_CDC_DOCTOR_QUEUE:}
       cdc.recommendation: ${SQS_CDC_RECOMMENDATION_QUEUE:}
       cdc.connectionlog: ${SQS_CDC_CONNECTION_QUEUE:}
+      cdc.hiddendiscrepancy: ${SQS_CDC_HIDDEN_DISCREPANCY_QUEUE:}
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcHiddenDiscrepancyHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/handler/CdcHiddenDiscrepancyHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.cdc.message.handler;
+
+import static org.mockito.Mockito.verify;
+
+import javax.naming.OperationNotSupportedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.integration.cdc.message.testutil.CdcTestDataGenerator;
+import uk.nhs.hee.tis.revalidation.integration.cdc.service.CdcHiddenDiscrepancyService;
+
+@ExtendWith(MockitoExtension.class)
+class CdcHiddenDiscrepancyHandlerTest {
+
+  @InjectMocks
+  CdcHiddenDiscrepancyMessageHandler cdcHiddenDiscrepancyMessageHandler;
+
+  @Mock
+  CdcHiddenDiscrepancyService cdcHiddenDiscrepancyService;
+
+  @Test
+  void shouldHandleInserts() throws OperationNotSupportedException {
+    var testMessage = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
+    cdcHiddenDiscrepancyMessageHandler.handleMessage(testMessage);
+
+    verify(cdcHiddenDiscrepancyService).upsertEntity(testMessage.getFullDocument());
+  }
+
+  @Test
+  void shouldHandleDeletes() throws OperationNotSupportedException {
+    var testMessage = CdcTestDataGenerator.getCdcHiddenDiscrepancyDeleteCdcDocumentDto();
+    cdcHiddenDiscrepancyMessageHandler.handleMessage(testMessage);
+
+    verify(cdcHiddenDiscrepancyService).deleteEntity(testMessage.getFullDocument());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListenerTest.java
@@ -110,9 +110,8 @@ class CdcSqsMessageListenerTest {
   @Test
   void shouldPassHiddenDiscrepancyInsertMessageFromSqsQueueToHandler()
       throws OperationNotSupportedException, IOException {
-    var testMessage = objectMapper.writeValueAsString(
-        CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto()
-    );
+    var dto = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
+    var testMessage = objectMapper.writeValueAsString(dto);
     cdcSqsMessageListener.getHiddenDiscrepancyMessage(testMessage);
 
     verify(cdcHiddenDiscrepancyMessageHandler).handleMessage(

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/listener/CdcSqsMessageListenerTest.java
@@ -36,10 +36,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcConnectionMessageHandler;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcDoctorMessageHandler;
+import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcHiddenDiscrepancyMessageHandler;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.handler.CdcRecommendationMessageHandler;
 import uk.nhs.hee.tis.revalidation.integration.cdc.message.testutil.CdcTestDataGenerator;
 import uk.nhs.hee.tis.revalidation.integration.entity.ConnectionLog;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.entity.Recommendation;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,6 +59,9 @@ class CdcSqsMessageListenerTest {
   @Mock
   CdcConnectionMessageHandler cdcConnectionMessageHandler;
 
+  @Mock
+  CdcHiddenDiscrepancyMessageHandler cdcHiddenDiscrepancyMessageHandler;
+
   @Spy
   ObjectMapper objectMapper;
 
@@ -69,7 +74,8 @@ class CdcSqsMessageListenerTest {
     cdcSqsMessageListener.getDoctorMessage(testMessage);
 
     verify(cdcDoctorMessageHandler).handleMessage(
-        objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {})
+        objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<DoctorsForDB>>() {
+        })
     );
   }
 
@@ -82,7 +88,8 @@ class CdcSqsMessageListenerTest {
     cdcSqsMessageListener.getRecommendationMessage(testMessage);
 
     verify(cdcRecommendationMessageHandler).handleMessage(
-        objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<Recommendation>>() {})
+        objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<Recommendation>>() {
+        })
     );
   }
 
@@ -96,6 +103,34 @@ class CdcSqsMessageListenerTest {
 
     verify(cdcConnectionMessageHandler).handleMessage(
         objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<ConnectionLog>>() {
+        })
+    );
+  }
+
+  @Test
+  void shouldPassHiddenDiscrepancyInsertMessageFromSqsQueueToHandler()
+      throws OperationNotSupportedException, IOException {
+    var testMessage = objectMapper.writeValueAsString(
+        CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto()
+    );
+    cdcSqsMessageListener.getHiddenDiscrepancyMessage(testMessage);
+
+    verify(cdcHiddenDiscrepancyMessageHandler).handleMessage(
+        objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<HiddenDiscrepancy>>() {
+        })
+    );
+  }
+
+  @Test
+  void shouldPassHiddenDiscrepancyDeleteMessageFromSqsQueueToHandler()
+      throws OperationNotSupportedException, IOException {
+    var testMessage = objectMapper.writeValueAsString(
+        CdcTestDataGenerator.getCdcHiddenDiscrepancyDeleteCdcDocumentDto()
+    );
+    cdcSqsMessageListener.getHiddenDiscrepancyMessage(testMessage);
+
+    verify(cdcHiddenDiscrepancyMessageHandler).handleMessage(
+        objectMapper.readValue(testMessage, new TypeReference<CdcDocumentDto<HiddenDiscrepancy>>() {
         })
     );
   }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -29,11 +29,13 @@ import static uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice.YES;
 import com.mongodb.client.model.changestream.OperationType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.CdcDocumentDto;
 import uk.nhs.hee.tis.revalidation.integration.cdc.dto.ConnectionInfoDto;
 import uk.nhs.hee.tis.revalidation.integration.entity.ConnectionLog;
 import uk.nhs.hee.tis.revalidation.integration.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.entity.Recommendation;
 import uk.nhs.hee.tis.revalidation.integration.entity.RecommendationStatus;
 import uk.nhs.hee.tis.revalidation.integration.entity.UnderNotice;
@@ -63,6 +65,7 @@ public class CdcTestDataGenerator {
   private static final String SUCCESSFUL_REQUEST_RESPONSE_CODE = "0";
   private static final String INTERNAL_ERROR_RESPONSE_CODE = "98";
   private static final String UPDATED_BY_GMC = "Updated by GMC";
+  private static final String HIDDEN_REASON_VAL = "reason";
 
   private static DoctorsForDB doctorsForDB = DoctorsForDB.builder()
       .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
@@ -111,6 +114,55 @@ public class CdcTestDataGenerator {
         .lastUpdatedDate(LocalDate.now())
         .admin("old" + ADMIN)
         .existsInGmc(false)
+        .build();
+  }
+
+  /**
+   * Get a test instance of MasterDoctorView.
+   *
+   * @return MasterDoctorView test instance with hidden discrepancies
+   */
+  public static MasterDoctorView getTestMasterDoctorViewWithHidden() {
+    return MasterDoctorView.builder()
+        .id("1")
+        .tcsPersonId(1L)
+        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .doctorFirstName("old" + DOCTOR_FIRST_NAME_VAL)
+        .doctorLastName("old" + DOCTOR_LAST_NAME_VAL)
+        .submissionDate(LocalDate.now())
+        .designatedBody("old" + DESIGNATED_BODY_CODE_VAL)
+        .tisStatus(DRAFT)
+        .lastUpdatedDate(LocalDate.now())
+        .admin("old" + ADMIN)
+        .existsInGmc(false)
+        .hiddenDiscrepancies(List.of(
+            getCdcHiddenDiscrepancyInsertCdcDocumentDto().getFullDocument()
+        ))
+        .build();
+  }
+
+  /**
+   * Get a test instance of MasterDoctorView.
+   *
+   * @return MasterDoctorView test instance with hidden discrepancies
+   */
+  public static MasterDoctorView getTestMasterDoctorViewWithMultipleHidden() {
+    return MasterDoctorView.builder()
+        .id("1")
+        .tcsPersonId(1L)
+        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .doctorFirstName("old" + DOCTOR_FIRST_NAME_VAL)
+        .doctorLastName("old" + DOCTOR_LAST_NAME_VAL)
+        .submissionDate(LocalDate.now())
+        .designatedBody("old" + DESIGNATED_BODY_CODE_VAL)
+        .tisStatus(DRAFT)
+        .lastUpdatedDate(LocalDate.now())
+        .admin("old" + ADMIN)
+        .existsInGmc(false)
+        .hiddenDiscrepancies(List.of(
+            getCdcHiddenDiscrepancyInsertCdcDocumentDto().getFullDocument(),
+            getSecondHiddenDiscrepancyInsertCdcDocumentDto().getFullDocument()
+        ))
         .build();
   }
 
@@ -165,16 +217,15 @@ public class CdcTestDataGenerator {
    *
    * @return CdcDocumentDto CdcRecommendation insert test instance
    */
-  public static CdcDocumentDto<Recommendation>
-      getCdcRecommendationInsertCdcDocumentDtoNullOutcome() {
-        Recommendation recommendation = Recommendation.builder()
-          .id("1")
-          .gmcNumber(GMC_REFERENCE_NUMBER_VAL)
-          .recommendationType(RecommendationType.REVALIDATE)
-          .recommendationStatus(DRAFT)
-          .gmcSubmissionDate(LocalDate.now().plusMonths(6))
-          .admin(ADMIN_VAL)
-          .build();
+  public static CdcDocumentDto<Recommendation> getRecommendationInsertCdcDocumentDtoNullOutcome() {
+    Recommendation recommendation = Recommendation.builder()
+        .id("1")
+        .gmcNumber(GMC_REFERENCE_NUMBER_VAL)
+        .recommendationType(RecommendationType.REVALIDATE)
+        .recommendationStatus(DRAFT)
+        .gmcSubmissionDate(LocalDate.now().plusMonths(6))
+        .admin(ADMIN_VAL)
+        .build();
 
     return new CdcDocumentDto<Recommendation>(OperationType.INSERT.getValue(), recommendation);
   }
@@ -305,4 +356,62 @@ public class CdcTestDataGenerator {
 
     return new CdcDocumentDto<ConnectionLog>(OperationType.INSERT.getValue(), connectionLog);
   }
+
+  /**
+   * Get a test instance of an insert HiddenDiscrepancy CdcDocumentDto.
+   *
+   * @return CdcDocumentDto HiddenDiscrepancy insert test instance
+   */
+  public static CdcDocumentDto<HiddenDiscrepancy> getCdcHiddenDiscrepancyInsertCdcDocumentDto() {
+    HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
+        .id("1")
+        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .hiddenDateTime(LocalDateTime.now())
+        .hiddenBy(ADMIN_VAL)
+        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_VAL)
+        .reason(HIDDEN_REASON_VAL)
+        .build();
+
+    return new CdcDocumentDto<HiddenDiscrepancy>(OperationType.INSERT.getValue(),
+        hiddenDiscrepancy);
+  }
+
+  /**
+   * Get a test instance of a second insert HiddenDiscrepancy CdcDocumentDto.
+   *
+   * @return CdcDocumentDto HiddenDiscrepancy insert test instance
+   */
+  public static CdcDocumentDto<HiddenDiscrepancy> getSecondHiddenDiscrepancyInsertCdcDocumentDto() {
+    HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
+        .id("2")
+        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .hiddenDateTime(LocalDateTime.now())
+        .hiddenBy(ADMIN_VAL)
+        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_VAL + "2")
+        .reason(HIDDEN_REASON_VAL)
+        .build();
+
+    return new CdcDocumentDto<HiddenDiscrepancy>(OperationType.INSERT.getValue(),
+        hiddenDiscrepancy);
+  }
+
+  /**
+   * Get a test instance of a deleted HiddenDiscrepancy CdcDocumentDto.
+   *
+   * @return CdcDocumentDto HiddenDiscrepancy deleted test instance
+   */
+  public static CdcDocumentDto<HiddenDiscrepancy> getCdcHiddenDiscrepancyDeleteCdcDocumentDto() {
+    HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
+        .id("2")
+        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .hiddenDateTime(LocalDateTime.now())
+        .hiddenBy(ADMIN_VAL)
+        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_VAL)
+        .reason(HIDDEN_REASON_VAL)
+        .build();
+
+    return new CdcDocumentDto<HiddenDiscrepancy>(OperationType.DELETE.getValue(),
+        hiddenDiscrepancy);
+  }
+
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/testutil/CdcTestDataGenerator.java
@@ -365,7 +365,7 @@ public class CdcTestDataGenerator {
   public static CdcDocumentDto<HiddenDiscrepancy> getCdcHiddenDiscrepancyInsertCdcDocumentDto() {
     HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
         .id("1")
-        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .gmcId(GMC_REFERENCE_NUMBER_VAL)
         .hiddenDateTime(LocalDateTime.now())
         .hiddenBy(ADMIN_VAL)
         .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_VAL)
@@ -384,7 +384,7 @@ public class CdcTestDataGenerator {
   public static CdcDocumentDto<HiddenDiscrepancy> getSecondHiddenDiscrepancyInsertCdcDocumentDto() {
     HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
         .id("2")
-        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .gmcId(GMC_REFERENCE_NUMBER_VAL)
         .hiddenDateTime(LocalDateTime.now())
         .hiddenBy(ADMIN_VAL)
         .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_VAL + "2")
@@ -403,7 +403,7 @@ public class CdcTestDataGenerator {
   public static CdcDocumentDto<HiddenDiscrepancy> getCdcHiddenDiscrepancyDeleteCdcDocumentDto() {
     HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
         .id("2")
-        .gmcReferenceNumber(GMC_REFERENCE_NUMBER_VAL)
+        .gmcId(GMC_REFERENCE_NUMBER_VAL)
         .hiddenDateTime(LocalDateTime.now())
         .hiddenBy(ADMIN_VAL)
         .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_VAL)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcConnectionServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcConnectionServiceTest.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.revalidation.integration.cdc.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -33,6 +34,7 @@ import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.
 
 import java.util.Collections;
 import java.util.Map;
+import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.common.collect.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -126,5 +128,14 @@ class CdcConnectionServiceTest {
 
     verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
         anyMap(), eq(MasterDoctorView.class));
+  }
+
+  @Test
+  void shouldThrowNotImplementedExceptionOnDeleteEntityCall() {
+    var testEntity = CdcTestDataGenerator.getCdcConnectionLogInsertCdcDocumentDto()
+        .getFullDocument();
+    assertThrows(NotImplementedException.class,
+        () -> cdcConnectionService.deleteEntity(testEntity)
+    );
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcDoctorServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcDoctorServiceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.
 
 import java.util.Collections;
 import java.util.Map;
+import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.common.collect.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -130,5 +132,12 @@ class CdcDoctorServiceTest {
         esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
 
     assertNull(esUpdateDocCaptor.getValue().get("designatedBody"));
+  }
+
+  @Test
+  void shouldThrowNotImplementedExceptionOnDeleteEntityCall() {
+    var testEntity = CdcTestDataGenerator.getCdcDoctor();
+    assertThrows(NotImplementedException.class,
+        () -> cdcDoctorService.deleteEntity(testEntity));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyServiceTest.java
@@ -1,0 +1,167 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.integration.cdc.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.MASTER_DOCTOR_INDEX;
+
+import java.util.Collections;
+import java.util.Map;
+import org.elasticsearch.common.collect.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.integration.cdc.message.publisher.CdcMessagePublisher;
+import uk.nhs.hee.tis.revalidation.integration.cdc.message.testutil.CdcTestDataGenerator;
+import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
+import uk.nhs.hee.tis.revalidation.integration.sync.repository.MasterDoctorElasticSearchRepository;
+import uk.nhs.hee.tis.revalidation.integration.sync.view.MasterDoctorView;
+
+@ExtendWith(MockitoExtension.class)
+class CdcHiddenDiscrepancyServiceTest {
+
+  private final MasterDoctorView masterDoctorView = CdcTestDataGenerator
+      .getTestMasterDoctorView();
+  private final MasterDoctorView masterDoctorViewWithHidden = CdcTestDataGenerator
+      .getTestMasterDoctorViewWithHidden();
+  private final MasterDoctorView masterDoctorViewWithMultipleHidden = CdcTestDataGenerator
+      .getTestMasterDoctorViewWithMultipleHidden();
+  @InjectMocks
+  @Spy
+  CdcHiddenDiscrepancyService cdcHiddenDiscrepancyService;
+  @Mock
+  MasterDoctorElasticSearchRepository repository;
+  @Mock
+  EsDocUpdateHelper esUpdateHelper;
+  @Mock
+  CdcMessagePublisher publisher;
+  @Captor
+  ArgumentCaptor<Map<String, Object>> esUpdateDocCaptor;
+
+  private static final String HIDDEN_DISCREPANCIES_KEY = "hiddenDiscrepancies";
+
+  @Test
+  void shouldAddNewField() {
+    when(repository.findByGmcReferenceNumber(any())).thenReturn(List.of(masterDoctorView));
+
+    var newHiddenDiscrepancy = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
+    cdcHiddenDiscrepancyService.upsertEntity(newHiddenDiscrepancy.getFullDocument());
+
+    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
+        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+
+    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
+        is(HIDDEN_DISCREPANCIES_KEY));
+    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
+        is(List.of(newHiddenDiscrepancy.getFullDocument())));
+  }
+
+  @Test
+  void shouldAddRecordToExistingField() {
+    when(repository.findByGmcReferenceNumber(any())).thenReturn(
+        List.of(masterDoctorViewWithHidden));
+
+    var newHiddenDiscrepancy = CdcTestDataGenerator
+        .getSecondHiddenDiscrepancyInsertCdcDocumentDto();
+    cdcHiddenDiscrepancyService.upsertEntity(newHiddenDiscrepancy.getFullDocument());
+
+    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
+        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+
+    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
+        is(HIDDEN_DISCREPANCIES_KEY));
+    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
+        is(List.of(masterDoctorViewWithHidden.getHiddenDiscrepancies().get(0),
+            newHiddenDiscrepancy.getFullDocument())));
+  }
+
+  @Test
+  void shouldNotInsertRecordIfDoctorDoesNotExist() {
+    when(repository.findByGmcReferenceNumber(any())).thenReturn(Collections.emptyList());
+
+    var newConnectionLog = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
+    cdcHiddenDiscrepancyService.upsertEntity(newConnectionLog.getFullDocument());
+
+    verify(esUpdateHelper, never()).partialUpdate(eq(MASTER_DOCTOR_INDEX),
+        eq(masterDoctorView.getId()),
+        anyMap(), eq(MasterDoctorView.class));
+  }
+
+  @Test
+  void shouldRemoveRecordsFromOnDeleteOperation() {
+    when(repository.findByGmcReferenceNumber(any())).thenReturn(List.of(masterDoctorView));
+
+    var newHiddenDiscrepancy = CdcTestDataGenerator.getCdcHiddenDiscrepancyDeleteCdcDocumentDto();
+    cdcHiddenDiscrepancyService.deleteEntity(newHiddenDiscrepancy.getFullDocument());
+
+    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
+        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+
+    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
+        is(HIDDEN_DISCREPANCIES_KEY));
+    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
+        is(Collections.emptyList()));
+  }
+
+  @Test
+  void shouldRemoveIndividualRecordsFromFieldOnDeleteOperation() {
+    when(repository.findByGmcReferenceNumber(any())).thenReturn(
+        List.of(masterDoctorViewWithMultipleHidden));
+
+    var deletedHiddenDiscrepancy = CdcTestDataGenerator
+        .getCdcHiddenDiscrepancyDeleteCdcDocumentDto();
+    cdcHiddenDiscrepancyService.deleteEntity(deletedHiddenDiscrepancy.getFullDocument());
+
+    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
+        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+
+    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
+        is(HIDDEN_DISCREPANCIES_KEY));
+    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
+        is(List.of(masterDoctorViewWithMultipleHidden.getHiddenDiscrepancies().get(1))));
+  }
+
+  @Test
+  void shouldNotAddSecondRecordIfAlreadyHiddenForDesignatedBodyAndGmcReferenceNumber() {
+    when(repository.findByGmcReferenceNumber(any())).thenReturn(
+        List.of(masterDoctorViewWithHidden));
+
+    var newConnectionLog = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
+    cdcHiddenDiscrepancyService.upsertEntity(newConnectionLog.getFullDocument());
+
+    verify(esUpdateHelper, never()).partialUpdate(eq(MASTER_DOCTOR_INDEX),
+        eq(masterDoctorView.getId()),
+        anyMap(), eq(MasterDoctorView.class));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyServiceTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.MASTER_DOCTOR_INDEX;
 
 import java.util.Collections;
-import java.util.Map;
 import org.elasticsearch.common.collect.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,7 +66,7 @@ class CdcHiddenDiscrepancyServiceTest {
   @Mock
   CdcMessagePublisher publisher;
   @Captor
-  ArgumentCaptor<Map<String, Object>> esUpdateDocCaptor;
+  ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor;
 
   private static final String HIDDEN_DISCREPANCIES_KEY = "hiddenDiscrepancies";
 
@@ -78,12 +77,9 @@ class CdcHiddenDiscrepancyServiceTest {
     var newHiddenDiscrepancy = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
     cdcHiddenDiscrepancyService.upsertEntity(newHiddenDiscrepancy.getFullDocument());
 
-    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
-        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+    verify(repository).save(masterDoctorViewCaptor.capture());
 
-    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
-        is(HIDDEN_DISCREPANCIES_KEY));
-    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
+    assertThat(masterDoctorViewCaptor.getValue().getHiddenDiscrepancies(),
         is(List.of(newHiddenDiscrepancy.getFullDocument())));
   }
 
@@ -96,14 +92,9 @@ class CdcHiddenDiscrepancyServiceTest {
         .getSecondHiddenDiscrepancyInsertCdcDocumentDto();
     cdcHiddenDiscrepancyService.upsertEntity(newHiddenDiscrepancy.getFullDocument());
 
-    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
-        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+    verify(repository).save(masterDoctorViewCaptor.capture());
 
-    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
-        is(HIDDEN_DISCREPANCIES_KEY));
-    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
-        is(List.of(masterDoctorViewWithHidden.getHiddenDiscrepancies().get(0),
-            newHiddenDiscrepancy.getFullDocument())));
+    assertThat(masterDoctorViewCaptor.getValue().getHiddenDiscrepancies().size(), is(2));
   }
 
   @Test
@@ -113,9 +104,7 @@ class CdcHiddenDiscrepancyServiceTest {
     var newConnectionLog = CdcTestDataGenerator.getCdcHiddenDiscrepancyInsertCdcDocumentDto();
     cdcHiddenDiscrepancyService.upsertEntity(newConnectionLog.getFullDocument());
 
-    verify(esUpdateHelper, never()).partialUpdate(eq(MASTER_DOCTOR_INDEX),
-        eq(masterDoctorView.getId()),
-        anyMap(), eq(MasterDoctorView.class));
+    verify(repository, never()).save(any());
   }
 
   @Test
@@ -125,12 +114,9 @@ class CdcHiddenDiscrepancyServiceTest {
     var newHiddenDiscrepancy = CdcTestDataGenerator.getCdcHiddenDiscrepancyDeleteCdcDocumentDto();
     cdcHiddenDiscrepancyService.deleteEntity(newHiddenDiscrepancy.getFullDocument());
 
-    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
-        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+    verify(repository).save(masterDoctorViewCaptor.capture());
 
-    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
-        is(HIDDEN_DISCREPANCIES_KEY));
-    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
+    assertThat(masterDoctorViewCaptor.getValue().getHiddenDiscrepancies(),
         is(Collections.emptyList()));
   }
 
@@ -143,13 +129,9 @@ class CdcHiddenDiscrepancyServiceTest {
         .getCdcHiddenDiscrepancyDeleteCdcDocumentDto();
     cdcHiddenDiscrepancyService.deleteEntity(deletedHiddenDiscrepancy.getFullDocument());
 
-    verify(esUpdateHelper).partialUpdate(eq(MASTER_DOCTOR_INDEX), eq(masterDoctorView.getId()),
-        esUpdateDocCaptor.capture(), eq(MasterDoctorView.class));
+    verify(repository).save(masterDoctorViewCaptor.capture());
 
-    assertThat(esUpdateDocCaptor.getValue().keySet().stream().findFirst().get(),
-        is(HIDDEN_DISCREPANCIES_KEY));
-    assertThat(esUpdateDocCaptor.getValue().get(HIDDEN_DISCREPANCIES_KEY),
-        is(List.of(masterDoctorViewWithMultipleHidden.getHiddenDiscrepancies().get(1))));
+    assertThat(masterDoctorViewCaptor.getValue().getHiddenDiscrepancies().size(), is(1));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcHiddenDiscrepancyServiceTest.java
@@ -68,8 +68,6 @@ class CdcHiddenDiscrepancyServiceTest {
   @Captor
   ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor;
 
-  private static final String HIDDEN_DISCREPANCIES_KEY = "hiddenDiscrepancies";
-
   @Test
   void shouldAddNewField() {
     when(repository.findByGmcReferenceNumber(any())).thenReturn(List.of(masterDoctorView));

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcRecommendationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcRecommendationServiceTest.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.revalidation.integration.cdc.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.revalidation.integration.config.EsConstant.Indexes.MASTER_DOCTOR_INDEX;
 
 import java.util.Collections;
+import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.common.collect.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -95,8 +97,18 @@ class CdcRecommendationServiceTest {
         anyMap(), eq(MasterDoctorView.class))).thenReturn(masterDoctorView);
 
     var newRecommendation = CdcTestDataGenerator
-        .getCdcRecommendationInsertCdcDocumentDtoNullOutcome();
+        .getRecommendationInsertCdcDocumentDtoNullOutcome();
     assertDoesNotThrow(
         () -> cdcRecommendationService.upsertEntity(newRecommendation.getFullDocument()));
+  }
+
+  @Test
+  void shouldThrowNotImplementedExceptionOnDeleteEntityCall() {
+    var testEntity = CdcTestDataGenerator.getCdcRecommendationInsertCdcDocumentDto()
+        .getFullDocument();
+    assertThrows(NotImplementedException.class,
+        () -> cdcRecommendationService.deleteEntity(
+            testEntity
+        ));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/cdc/service/CdcTraineeUpdateServiceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.when;
 import com.github.javafaker.Faker;
 import java.time.LocalDate;
 import java.util.Collections;
+import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.common.collect.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -240,5 +242,11 @@ class CdcTraineeUpdateServiceTest {
     assertThat(savedEntity.getCurriculumEndDate(), nullValue());
     assertThat(savedEntity.getMembershipType(), nullValue());
     assertThat(savedEntity.getPlacementGrade(), nullValue());
+  }
+
+  @Test
+  void shouldThrowNotImplementedExceptionOnDeleteEntityCall() {
+    assertThrows(NotImplementedException.class,
+        () -> cdcTraineeUpdateService.deleteEntity(traineeUpdate));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/HiddenDiscrepancyMessageListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/listener/HiddenDiscrepancyMessageListenerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2025 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -24,10 +24,8 @@ package uk.nhs.hee.tis.revalidation.integration.sync.listener;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -35,53 +33,28 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import uk.nhs.hee.tis.revalidation.integration.router.dto.ConnectionLogDto;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.router.message.payload.IndexSyncMessage;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.DoctorUpsertElasticSearchService;
 import uk.nhs.hee.tis.revalidation.integration.sync.service.ElasticsearchIndexService;
 
 @ExtendWith(MockitoExtension.class)
-class ConnectionLogMessageListenerTest {
+class HiddenDiscrepancyMessageListenerTest {
 
   @Captor
-  ArgumentCaptor<List<ConnectionLogDto>> payloadArgCaptor;
+  ArgumentCaptor<List<HiddenDiscrepancy>> payloadArgCaptor;
   @Mock
   private DoctorUpsertElasticSearchService doctorUpsertElasticSearchService;
   @Mock
   private ElasticsearchIndexService elasticsearchIndexService;
-  @Mock
-  private RabbitTemplate rabbitTemplate;
   @InjectMocks
-  private ConnectionLogMessageListener listener;
-
-  @BeforeEach
-  void setup() {
-    setField(listener, "revalExchange", "exchange");
-    setField(listener, "hiddenDiscrepanciesSyncRoutingKey", "routingKey");
-  }
-
-  @Test
-  void shouldTriggerHiddenDiscrepanciesSyncWhenAllConnectionLogsSaved() {
-    // given
-    IndexSyncMessage<List<ConnectionLogDto>> msg = new IndexSyncMessage<>();
-    msg.setSyncEnd(true);
-
-    // when
-    listener.receiveConnectionLogMessage(msg);
-
-    // then
-    verify(rabbitTemplate)
-        .convertAndSend(
-            "exchange", "routingKey", "hiddenDiscrepancySyncStart"
-        );
-  }
+  private HiddenDiscrepancyMessageListener listener;
 
   @Test
   void shouldPopulateMasterIndexWhenSyncEndIsFalse() {
     // given
-    List<ConnectionLogDto> payload = List.of(new ConnectionLogDto());
-    IndexSyncMessage<List<ConnectionLogDto>> msg = new IndexSyncMessage<>();
+    List<HiddenDiscrepancy> payload = List.of(new HiddenDiscrepancy());
+    IndexSyncMessage<List<HiddenDiscrepancy>> msg = new IndexSyncMessage<>();
     msg.setSyncEnd(false);
     msg.setPayload(payload);
 
@@ -89,7 +62,7 @@ class ConnectionLogMessageListenerTest {
     listener.receiveConnectionLogMessage(msg);
 
     // then
-    verify(doctorUpsertElasticSearchService).populateMasterIndexByConnectionLogs(
+    verify(doctorUpsertElasticSearchService).populateMasterIndexByHiddenDiscrepancies(
         payloadArgCaptor.capture());
     verifyNoInteractions(elasticsearchIndexService);
     assertEquals(payload, payloadArgCaptor.getValue());

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -56,6 +56,7 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import uk.nhs.hee.tis.revalidation.integration.cdc.repository.custom.EsDocUpdateHelper;
+import uk.nhs.hee.tis.revalidation.integration.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.integration.router.dto.ConnectionLogDto;
 import uk.nhs.hee.tis.revalidation.integration.router.mapper.MasterDoctorViewMapper;
 import uk.nhs.hee.tis.revalidation.integration.sync.helper.ElasticsearchIndexHelper;
@@ -92,6 +93,8 @@ class DoctorUpsertElasticSearchServiceTest {
   private ArgumentCaptor<List<MasterDoctorView>> updateListCaptor;
   @InjectMocks
   private DoctorUpsertElasticSearchService service;
+  @Mock
+  private MasterDoctorView masterDoctorViewMock;
   private MasterDoctorView currentDoctorView;
   private MasterDoctorView dataToSave;
   private MasterDoctorView mappedView;
@@ -110,8 +113,12 @@ class DoctorUpsertElasticSearchServiceTest {
   private static final String DOCTOR_LAST_NAME = "lastName";
   private static final String DOCTOR_LAST_NAME_KEY = "doctorLastName";
   private static final String DOCTOR_LAST_NAME_NEW = "lastName_new";
+  private static final String DESIGNATED_BODY_CODE_1 = "1111111";
+  private static final String DESIGNATED_BODY_CODE_2 = "2222222";
   private static final LocalDateTime LAST_CONNECTION_DATETIME = LocalDateTime.now().minusDays(1);
   private ConnectionLogDto connectionLogDto;
+  HiddenDiscrepancy hiddenDiscrepancy1;
+  HiddenDiscrepancy hiddenDiscrepancy2;
 
   @BeforeEach
   void setUp() {
@@ -153,6 +160,21 @@ class DoctorUpsertElasticSearchServiceTest {
         .gmcId(GMC_NUMBER)
         .updatedBy(UPDATED_BY)
         .eventDateTime(LAST_CONNECTION_DATETIME)
+        .build();
+
+    hiddenDiscrepancy1 = HiddenDiscrepancy.builder()
+        .gmcReferenceNumber(GMC_NUMBER)
+        .hiddenDateTime(LocalDateTime.now())
+        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_1)
+        .reason("reason1")
+        .hiddenBy(UPDATED_BY)
+        .build();
+    hiddenDiscrepancy2 = HiddenDiscrepancy.builder()
+        .gmcReferenceNumber(GMC_NUMBER)
+        .hiddenDateTime(LocalDateTime.now())
+        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_2)
+        .reason("reason2")
+        .hiddenBy(UPDATED_BY)
         .build();
 
     // prepare existing record in ES Master
@@ -376,6 +398,68 @@ class DoctorUpsertElasticSearchServiceTest {
   @Test
   void shouldHandleEmptyConnectionLogList() {
     service.populateMasterIndexByConnectionLogs(Collections.emptyList());
+    verify(esDocUpdateHelper, never()).bulkPartialUpdate(any(), any());
+  }
+
+  @Test
+  void shouldBulkUpdateExistingDoctorsWithHiddenDiscrepancies() {
+    when(repository.findByGmcReferenceNumber(GMC_NUMBER)).thenReturn(
+        List.of(masterDoctorViewMock));
+    when(masterDoctorViewMock.getId()).thenReturn(DOCUMENT_ID);
+    when(masterDoctorViewMock.getHiddenDiscrepancies())
+        .thenReturn(null, List.of(hiddenDiscrepancy1));
+
+    service.populateMasterIndexByHiddenDiscrepancies(
+        List.of(hiddenDiscrepancy1, hiddenDiscrepancy2));
+
+    verify(esDocUpdateHelper, times(2)).bulkPartialUpdate(eq(MASTER_DOCTOR_INDEX),
+        bulkUpdateCaptor.capture());
+
+    Map<String, Object> savedFields1 = Map.of();
+    Map<String, Object> savedFields2 = Map.of();
+    String updatedId1 = "";
+    String updatedId2 = "";
+
+    var result1 = bulkUpdateCaptor.getAllValues().get(0);
+    var result2 = bulkUpdateCaptor.getAllValues().get(1);
+
+    for (var entry : result1.entrySet()) {
+      savedFields1 = entry.getValue();
+      updatedId1 = entry.getKey();
+    }
+
+    for (var entry : result2.entrySet()) {
+      savedFields2 = entry.getValue();
+      updatedId2 = entry.getKey();
+    }
+
+    assertEquals(List.of(hiddenDiscrepancy1), savedFields1.get("hiddenDiscrepancies"));
+    assertEquals(DOCUMENT_ID, updatedId1);
+    assertFalse(savedFields1.containsKey(TIS_ID_KEY)); // Fields from TIS/TCS not updated
+    assertFalse(savedFields1.containsKey(GMC_NUMBER_KEY)); // Fields from Recommendation not updated
+
+    assertEquals(List.of(hiddenDiscrepancy1, hiddenDiscrepancy2),
+        savedFields2.get("hiddenDiscrepancies"));
+    assertEquals(DOCUMENT_ID, updatedId2);
+    assertFalse(savedFields2.containsKey(TIS_ID_KEY)); // Fields from TIS/TCS not updated
+    assertFalse(savedFields2.containsKey(GMC_NUMBER_KEY)); // Fields from Recommendation not updated
+  }
+
+  @Test
+  void shouldNotBulkUpdateNewDoctorsWithHiddenDiscrepanciesIfNoExistingDoctors() {
+    when(repository.findByGmcReferenceNumber(
+        mappedNewViewGmcOnly.getGmcReferenceNumber())).thenReturn(
+        List.of());
+
+    service.populateMasterIndexByHiddenDiscrepancies(
+        List.of(hiddenDiscrepancy1, hiddenDiscrepancy2));
+
+    verify(esDocUpdateHelper, never()).bulkPartialUpdate(any(), any());
+  }
+
+  @Test
+  void shouldHandleEmptyHiddenDiscrepanciesList() {
+    service.populateMasterIndexByHiddenDiscrepancies(Collections.emptyList());
     verify(esDocUpdateHelper, never()).bulkPartialUpdate(any(), any());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -91,10 +91,10 @@ class DoctorUpsertElasticSearchServiceTest {
   private ArgumentCaptor<String> routingKeyCaptor;
   @Captor
   private ArgumentCaptor<List<MasterDoctorView>> updateListCaptor;
+  @Captor
+  private ArgumentCaptor<MasterDoctorView> masterDoctorViewCaptor;
   @InjectMocks
   private DoctorUpsertElasticSearchService service;
-  @Mock
-  private MasterDoctorView masterDoctorViewMock;
   private MasterDoctorView currentDoctorView;
   private MasterDoctorView dataToSave;
   private MasterDoctorView mappedView;
@@ -402,47 +402,36 @@ class DoctorUpsertElasticSearchServiceTest {
   }
 
   @Test
-  void shouldBulkUpdateExistingDoctorsWithHiddenDiscrepancies() {
+  void shouldUpdateExistingDoctorsWithHiddenDiscrepancies() {
+    MasterDoctorView masterDoctorViewInitial = MasterDoctorView.builder()
+        .id(DOCUMENT_ID)
+        .tcsPersonId(TIS_ID)
+        .gmcReferenceNumber(GMC_NUMBER)
+        .doctorFirstName(DOCTOR_FIRST_NAME)
+        .doctorLastName(DOCTOR_LAST_NAME)
+        .build();
+
+    MasterDoctorView masterDoctorViewUpdated = MasterDoctorView.builder()
+        .id(DOCUMENT_ID)
+        .tcsPersonId(TIS_ID)
+        .gmcReferenceNumber(GMC_NUMBER)
+        .doctorFirstName(DOCTOR_FIRST_NAME)
+        .doctorLastName(DOCTOR_LAST_NAME)
+        .hiddenDiscrepancies(List.of(hiddenDiscrepancy1))
+        .build();
+
     when(repository.findByGmcReferenceNumber(GMC_NUMBER)).thenReturn(
-        List.of(masterDoctorViewMock));
-    when(masterDoctorViewMock.getId()).thenReturn(DOCUMENT_ID);
-    when(masterDoctorViewMock.getHiddenDiscrepancies())
-        .thenReturn(null, List.of(hiddenDiscrepancy1));
+        List.of(masterDoctorViewInitial), List.of(masterDoctorViewUpdated));
 
     service.populateMasterIndexByHiddenDiscrepancies(
         List.of(hiddenDiscrepancy1, hiddenDiscrepancy2));
 
-    verify(esDocUpdateHelper, times(2)).bulkPartialUpdate(eq(MASTER_DOCTOR_INDEX),
-        bulkUpdateCaptor.capture());
-
-    Map<String, Object> savedFields1 = Map.of();
-    Map<String, Object> savedFields2 = Map.of();
-    String updatedId1 = "";
-    String updatedId2 = "";
-
-    var result1 = bulkUpdateCaptor.getAllValues().get(0);
-    var result2 = bulkUpdateCaptor.getAllValues().get(1);
-
-    for (var entry : result1.entrySet()) {
-      savedFields1 = entry.getValue();
-      updatedId1 = entry.getKey();
-    }
-
-    for (var entry : result2.entrySet()) {
-      savedFields2 = entry.getValue();
-      updatedId2 = entry.getKey();
-    }
-
-    assertEquals(List.of(hiddenDiscrepancy1), savedFields1.get("hiddenDiscrepancies"));
-    assertEquals(DOCUMENT_ID, updatedId1);
-    assertFalse(savedFields1.containsKey(TIS_ID_KEY)); // Fields from TIS/TCS not updated
-    assertFalse(savedFields1.containsKey(GMC_NUMBER_KEY)); // Fields from Recommendation not updated
-
+    verify(repository, times(2)).save(masterDoctorViewCaptor.capture());
+    var savedDoctor1 = masterDoctorViewCaptor.getAllValues().get(0);
+    var savedDoctor2 = masterDoctorViewCaptor.getAllValues().get(1);
+    assertEquals(List.of(hiddenDiscrepancy1), savedDoctor1.getHiddenDiscrepancies());
     assertEquals(List.of(hiddenDiscrepancy1, hiddenDiscrepancy2),
-        savedFields2.get("hiddenDiscrepancies"));
-    assertEquals(DOCUMENT_ID, updatedId2);
-    assertFalse(savedFields2.containsKey(TIS_ID_KEY)); // Fields from TIS/TCS not updated
-    assertFalse(savedFields2.containsKey(GMC_NUMBER_KEY)); // Fields from Recommendation not updated
+        savedDoctor2.getHiddenDiscrepancies());
   }
 
   @Test
@@ -454,12 +443,12 @@ class DoctorUpsertElasticSearchServiceTest {
     service.populateMasterIndexByHiddenDiscrepancies(
         List.of(hiddenDiscrepancy1, hiddenDiscrepancy2));
 
-    verify(esDocUpdateHelper, never()).bulkPartialUpdate(any(), any());
+    verify(repository, never()).save(any());
   }
 
   @Test
   void shouldHandleEmptyHiddenDiscrepanciesList() {
     service.populateMasterIndexByHiddenDiscrepancies(Collections.emptyList());
-    verify(esDocUpdateHelper, never()).bulkPartialUpdate(any(), any());
+    verify(repository, never()).save(any());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/integration/sync/service/DoctorUpsertElasticSearchServiceTest.java
@@ -163,14 +163,14 @@ class DoctorUpsertElasticSearchServiceTest {
         .build();
 
     hiddenDiscrepancy1 = HiddenDiscrepancy.builder()
-        .gmcReferenceNumber(GMC_NUMBER)
+        .gmcId(GMC_NUMBER)
         .hiddenDateTime(LocalDateTime.now())
         .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_1)
         .reason("reason1")
         .hiddenBy(UPDATED_BY)
         .build();
     hiddenDiscrepancy2 = HiddenDiscrepancy.builder()
-        .gmcReferenceNumber(GMC_NUMBER)
+        .gmcId(GMC_NUMBER)
         .hiddenDateTime(LocalDateTime.now())
         .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODE_2)
         .reason("reason2")


### PR DESCRIPTION
TIS21-8285: Simplified: Implement ability to manually permenantly hide and un-hide discrepancies