### PR TITLE
fix: correct time format for cdc deserializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.15.2"
+version = "0.15.3"
 sourceCompatibility = "17"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcLocalDateTimeDeserializer.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/integration/cdc/message/util/CdcLocalDateTimeDeserializer.java
@@ -40,7 +40,7 @@ import java.time.format.DateTimeParseException;
 public class CdcLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
 
   private static final DateTimeFormatter CDC_DATE_FORMAT =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
   private final LocalDateTimeDeserializer localDateTimeDeserializer;
 


### PR DESCRIPTION
TIS21-8285

DateTimes of documents received from the CDC pipeline are stored as uuuu-MM-dd'T'HH:mm:ss.SSS, however when checking for existing documents with hiddendiscrepancies they are deserialized with yyyy-MM-dd HH:mm:ss, which causes a deserialization error 